### PR TITLE
Add Registry specification pages to package system docs

### DIFF
--- a/docs/guides/discover-methods.md
+++ b/docs/guides/discover-methods.md
@@ -136,3 +136,5 @@ The index is built automatically when you run search or graph commands, but buil
 - [The Know-How Graph](../know-how-graph/index.md) — how typed signatures enable semantic discovery.
 - [Cross-Package References](../packages/cross-package-references.md) — how to use discovered pipes in your bundles.
 - [Use Dependencies](use-dependencies.md) — how to add a discovered package as a dependency.
+- [The Registry](../packages/registry.md) — query remote registries for packages beyond your local cache.
+- [Registry Search](../packages/registry-search.md) — type-aware search semantics and concept compatibility rules.

--- a/docs/guides/publish-package.md
+++ b/docs/guides/publish-package.md
@@ -97,3 +97,4 @@ Follow [Semantic Versioning](https://semver.org/): increment the major version f
 - [The Manifest](../packages/manifest.md) — `address` and `version` field requirements.
 - [The Lock File](../packages/lock-file.md) — what gets locked and when.
 - [Distribution](../packages/distribution.md) — how packages are fetched by consumers.
+- [Registry Distribution Protocol](../packages/registry-distribution.md) — how to notify registries after publishing.

--- a/docs/know-how-graph/index.md
+++ b/docs/know-how-graph/index.md
@@ -73,3 +73,5 @@ The result is a federated network of composable, discoverable, type-safe AI meth
 - [Concepts](../language/concepts.md) — how concepts define typed data and refinement.
 - [Exports & Visibility](../packages/exports-visibility.md) — which pipes are visible in the graph.
 - [Distribution](../packages/distribution.md) — how registries index packages.
+- [The Registry](../packages/registry.md) — the HTTP service that exposes the Know-How Graph for remote queries.
+- [Registry Search](../packages/registry-search.md) — type-aware search semantics and graph query rules.

--- a/docs/packages/distribution.md
+++ b/docs/packages/distribution.md
@@ -75,6 +75,8 @@ MTHDS supports multiple deployment tiers, from local to community-wide:
 
 ## See Also
 
+- [The Registry](registry.md) — the HTTP service that indexes packages and powers discovery.
+- [Registry Distribution Protocol](registry-distribution.md) — proxy chains, signed manifests, and multi-tier deployment.
 - [Specification: Fetching Remote Dependencies](../spec/namespace-resolution.md#fetching-remote-dependencies) — normative reference for the fetch algorithm.
 - [Specification: Cache Layout](../spec/namespace-resolution.md#cache-layout) — normative reference for cache paths.
 - [The Lock File](lock-file.md) — how fetched versions are pinned.

--- a/docs/packages/registry-distribution.md
+++ b/docs/packages/registry-distribution.md
@@ -1,0 +1,198 @@
+---
+description: "Registry distribution protocol for MTHDS — proxy chains, signed manifests, social signals, and multi-tier deployment."
+---
+
+# Registry Distribution Protocol
+
+This page specifies how registries participate in the package distribution chain — acting as proxies, verifying package integrity, surfacing community signals, and supporting multi-tier deployment from local development to community-wide distribution.
+
+## Proxy Chain
+
+A client can be configured with an ordered list of registry URLs, analogous to Go's `GOPROXY` protocol. When resolving a package, the client queries registries in order:
+
+```
+MTHDS_REGISTRY=https://registry.example.com,https://community.mthds.ai,direct
+```
+
+| Entry | Behavior |
+|-------|----------|
+| A registry URL | Query the registry's `/v1/packages/{address}` endpoint. If the package is found, use it. If not (404), try the next entry. |
+| `direct` | Bypass registries and fetch directly from the Git repository at the package address. |
+
+The special value `direct` as the final entry ensures that packages not indexed by any registry can still be fetched from source. If `direct` is not present and no registry returns the package, resolution fails.
+
+### Proxy Mode
+
+A registry MAY operate in proxy mode, where it does not maintain its own index but forwards requests to an upstream registry and caches the results. A proxy registry:
+
+- MUST forward the original request path and query parameters.
+- MUST cache successful responses for a configurable duration.
+- MUST forward `404 Not Found` without caching (the upstream may index the package later).
+- SHOULD pass through the upstream's `Retry-After` headers on `429` responses.
+
+### Mirror Mode
+
+A registry MAY operate in mirror mode, where it maintains a full copy of another registry's index. A mirror registry:
+
+- MUST periodically synchronize with the upstream registry.
+- MUST serve requests from its local copy without forwarding.
+- SHOULD expose a `last_synced_at` timestamp so clients can assess freshness.
+
+## Signed Manifests
+
+To ensure package integrity, a registry MAY require or serve **signed manifests**. A signed manifest binds the `METHODS.toml` content to a cryptographic signature.
+
+### Signature Format
+
+A signature is a detached JSON object:
+
+```json
+{
+  "manifest_sha256": "a1b2c3d4e5f6...",
+  "address": "github.com/acme/legal-tools",
+  "version": "1.2.0",
+  "signed_at": "2026-01-15T10:30:00Z",
+  "signer": "acme-ci-bot",
+  "algorithm": "ed25519",
+  "public_key_id": "key-2026-01",
+  "signature": "base64-encoded-signature..."
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `manifest_sha256` | SHA-256 hash of the raw `METHODS.toml` file content. |
+| `address` | Package address, matching the manifest. |
+| `version` | Package version, matching the manifest. |
+| `signed_at` | ISO 8601 timestamp of when the signature was created. |
+| `signer` | Identifier of the signing entity (human or automation). |
+| `algorithm` | Signature algorithm. MUST be `ed25519`. |
+| `public_key_id` | Identifier for the public key used, for key rotation. |
+| `signature` | Base64-encoded Ed25519 signature over the canonical representation of the preceding fields. |
+
+### Verification
+
+When verifying a signed manifest:
+
+1. Compute the SHA-256 hash of the `METHODS.toml` file content.
+2. Compare it against `manifest_sha256`.
+3. Reconstruct the canonical signing payload (all fields except `signature`, serialized as sorted-key JSON with no whitespace).
+4. Verify the Ed25519 signature against the payload using the public key identified by `public_key_id`.
+
+A client SHOULD verify signatures when available. A client MUST NOT treat an unsigned package as verified.
+
+### Trust Store
+
+Public keys are stored in a trust store. A compliant runtime SHOULD support trust stores at two levels:
+
+| Level | Location | Purpose |
+|-------|----------|---------|
+| **System** | `~/.mthds/trust/` | Keys trusted for all projects. |
+| **Project** | `.mthds/trust/` in the project root | Keys trusted for this project only. |
+
+Each key file is named `{public_key_id}.pub` and contains the raw Ed25519 public key in base64 encoding.
+
+## Social Signals
+
+A registry MAY track and expose social signals to help users evaluate packages:
+
+| Signal | Description |
+|--------|-------------|
+| `install_count` | Number of times the package has been fetched through this registry. |
+| `star_count` | Number of users who have starred the package. |
+| `endorsed_by` | List of known organizations or users who endorse the package. |
+| `last_updated` | Timestamp of the latest indexed version. |
+| `indexed_at` | Timestamp of when the registry last crawled the package. |
+
+Social signals are informational. They MUST NOT affect search ranking in type-compatible queries (which are purely type-driven). A registry MAY use social signals to influence text search ranking.
+
+### Social Signals Endpoint
+
+```
+GET /v1/packages/{address}/signals
+```
+
+**Response:**
+
+```json
+{
+  "address": "github.com/acme/legal-tools",
+  "install_count": 1247,
+  "star_count": 42,
+  "endorsed_by": ["mthds-foundation"],
+  "last_updated": "2026-01-15T10:30:00Z",
+  "indexed_at": "2026-02-01T08:00:00Z"
+}
+```
+
+## Publish Notification
+
+After a package passes [publish validation](../guides/publish-package.md) and a version tag is pushed to Git, the CLI MAY notify one or more registries to trigger re-indexing:
+
+```
+POST /v1/packages/{address}/notify
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "version": "1.2.0",
+  "tag": "v1.2.0",
+  "clone_url": "https://github.com/acme/legal-tools.git"
+}
+```
+
+A registry MUST respond with `202 Accepted` if it acknowledges the notification. The actual re-indexing happens asynchronously.
+
+A registry MUST NOT require publish notification — it MUST be capable of discovering new versions through polling or webhooks independently.
+
+## Multi-Tier Deployment
+
+Registries support the same deployment tiers described in [Distribution](distribution.md):
+
+### Local Tier
+
+No registry involved. The CLI operates on the current project and its local cache (`~/.mthds/packages/`). Search and graph queries run against a locally-built index.
+
+### Project Tier
+
+A project team runs an internal registry indexing their shared packages. The registry URL is configured in the project's `.mthds/config.toml`:
+
+```toml
+[registry]
+urls = ["https://registry.internal.acme.com"]
+```
+
+### Organization Tier
+
+An organization runs a registry that acts as a proxy to the community registry, adding organization-specific packages and governance policies:
+
+```
+MTHDS_REGISTRY=https://registry.internal.acme.com,https://community.mthds.ai,direct
+```
+
+The internal registry can:
+
+- Index private packages not available on the community registry.
+- Enforce approval policies before indexing external packages.
+- Cache community packages for air-gapped environments.
+
+### Community Tier
+
+A public registry indexes open-source packages from public Git repositories. Anyone can notify the registry of a new package address. The registry crawls and indexes it.
+
+## Configuration
+
+Registry URLs are resolved in this order of precedence:
+
+1. **Environment variable**: `MTHDS_REGISTRY` (comma-separated list).
+2. **Project config**: `.mthds/config.toml` `[registry].urls` array.
+3. **User config**: `~/.mthds/config.toml` `[registry].urls` array.
+4. **Default**: `direct` (no registry, fetch from Git directly).
+
+## See Also
+
+- [The Registry](registry.md) — API endpoints and schemas.
+- [Registry Indexing](registry-indexing.md) — how registries build the index.
+- [Distribution](distribution.md) — the federated storage model that registries build upon.
+- [Publish a Package](../guides/publish-package.md) — how to publish and notify registries.
+- [Version Resolution](version-resolution.md) — how version constraints are resolved.

--- a/docs/packages/registry-indexing.md
+++ b/docs/packages/registry-indexing.md
@@ -1,0 +1,280 @@
+---
+description: "How an MTHDS registry discovers, crawls, and indexes packages — from Git repositories to PackageIndexEntry and Know-How Graph construction."
+---
+
+# Registry Indexing
+
+A registry builds its index by crawling Git-hosted packages, parsing their manifests and bundles, and constructing a [Know-How Graph](../know-how-graph/index.md) from the extracted metadata. This page specifies the indexing pipeline.
+
+## Indexing Pipeline
+
+The indexing pipeline transforms a package address into a `PackageIndexEntry`:
+
+```
+address → git clone → parse METHODS.toml → scan .mthds files → PackageIndexEntry
+```
+
+### Step 1: Clone the Repository
+
+The registry resolves the package address to a Git clone URL:
+
+1. Prepend `https://`.
+2. Append `.git` (if not already present).
+
+```
+github.com/acme/legal-tools → https://github.com/acme/legal-tools.git
+```
+
+The registry MUST use `git ls-remote --tags` to enumerate available version tags before cloning. Only tags that parse as valid [semantic versions](../packages/version-resolution.md) are considered. Both `v`-prefixed (e.g., `v1.0.0`) and bare (e.g., `1.0.0`) tags are recognized.
+
+The registry clones at the latest stable version tag using `git clone --depth 1 --branch {tag}`.
+
+### Step 2: Parse the Manifest
+
+The registry reads `METHODS.toml` from the package root. This provides:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | `string` | Package address (e.g., `github.com/acme/legal-tools`). |
+| `version` | `string` | Semantic version (e.g., `1.2.0`). |
+| `description` | `string` | Human-readable package description. |
+| `authors` | `list[string]` | Package authors. |
+| `license` | `string \| null` | SPDX license identifier. |
+| `dependencies` | `list[PackageDependency]` | Declared dependencies with address, version constraint, and alias. |
+| `exports` | `list[DomainExports]` | Which pipes are publicly visible, grouped by domain path. |
+
+If `METHODS.toml` is missing or fails validation, the registry MUST skip the package and log a warning. A malformed manifest MUST NOT cause the registry to stop indexing other packages.
+
+### Step 3: Scan Bundles
+
+The registry collects all `.mthds` files recursively from the package root. For each bundle file, it parses the MTHDS content and extracts:
+
+**Domains:**
+
+Each bundle declares a domain. The registry builds a `DomainEntry` for each unique domain encountered:
+
+```json
+{
+  "domain_code": "legal.contracts",
+  "description": "Contract processing domain"
+}
+```
+
+**Concepts:**
+
+Each concept definition produces a `ConceptEntry`:
+
+```json
+{
+  "concept_code": "ContractClause",
+  "domain_code": "legal.contracts",
+  "concept_ref": "legal.contracts.ContractClause",
+  "description": "A single clause extracted from a contract",
+  "refines": "native.Text",
+  "structure_fields": ["clause_type", "text", "section_number"]
+}
+```
+
+The `concept_ref` is always `{domain_code}.{concept_code}`. The `refines` field is the raw string from the bundle — it is resolved to a cross-package identity during [graph construction](#know-how-graph-construction).
+
+**Pipes:**
+
+Each pipe definition produces a `PipeSignature`:
+
+```json
+{
+  "pipe_code": "extract_clause",
+  "pipe_type": "PipeLLM",
+  "domain_code": "legal.contracts",
+  "description": "Extract a specific clause from a contract document",
+  "input_specs": { "source": "ContractDocument" },
+  "output_spec": "ContractClause",
+  "is_exported": true
+}
+```
+
+The `is_exported` flag is determined by the manifest's `[exports]` section:
+
+- If the manifest declares exports for the pipe's domain and the pipe code appears in the exports list, `is_exported` is `true`.
+- If the pipe is the bundle's `main_pipe`, it is auto-exported.
+- If no exports are declared at all (no manifest), all pipes are considered exported.
+
+### Step 4: Assemble the Index Entry
+
+The registry assembles a `PackageIndexEntry` from the parsed manifest and scanned bundles:
+
+```json
+{
+  "address": "github.com/acme/legal-tools",
+  "version": "1.2.0",
+  "description": "Contract analysis and clause extraction methods",
+  "authors": ["Acme Legal Team"],
+  "license": "Apache-2.0",
+  "domains": [
+    { "domain_code": "legal.contracts", "description": "Contract processing domain" }
+  ],
+  "concepts": [ ... ],
+  "pipes": [ ... ],
+  "dependencies": ["github.com/mthds/document-processing"],
+  "dependency_aliases": { "doc_processing": "github.com/mthds/document-processing" }
+}
+```
+
+The `dependencies` list contains raw addresses. The `dependency_aliases` map aliases to addresses, enabling [cross-package concept resolution](registry-search.md#cross-package-concept-resolution) during graph construction.
+
+Domains are sorted alphabetically by `domain_code`. Parse errors in individual bundles are logged as warnings — a single broken bundle MUST NOT prevent the rest of the package from being indexed.
+
+## The Package Index
+
+The `PackageIndex` is the collection of all `PackageIndexEntry` records, keyed by address:
+
+```json
+{
+  "entries": {
+    "github.com/acme/legal-tools": { ... },
+    "github.com/mthds/document-processing": { ... }
+  }
+}
+```
+
+Operations on the index:
+
+| Operation | Description |
+|-----------|-------------|
+| `add_entry` | Add or replace a package entry by address. |
+| `get_entry` | Retrieve an entry by address. Returns null if not indexed. |
+| `remove_entry` | Remove an entry by address. Returns whether the entry existed. |
+| `all_concepts` | Return all concepts across all packages as `(address, ConceptEntry)` pairs. |
+| `all_pipes` | Return all pipes across all packages as `(address, PipeSignature)` pairs. |
+
+## Know-How Graph Construction
+
+After building the package index, the registry constructs the Know-How Graph — a directed graph of concepts and pipes that enables [type-aware search](registry-search.md). The construction follows five steps:
+
+### Step 1: Build Concept Nodes
+
+For every concept in every indexed package, the registry creates a `ConceptNode` with a globally unique `ConceptId`:
+
+```json
+{
+  "concept_id": {
+    "package_address": "github.com/acme/legal-tools",
+    "concept_ref": "legal.contracts.ContractClause"
+  },
+  "description": "A single clause extracted from a contract",
+  "refines": null,
+  "structure_fields": ["clause_type", "text", "section_number"]
+}
+```
+
+The node key is `{package_address}::{concept_ref}` (e.g., `github.com/acme/legal-tools::legal.contracts.ContractClause`).
+
+The registry MUST also create concept nodes for all native concepts (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `ImgGenPrompt`, `Page`, `JSON`, `Anything`, `Dynamic`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
+
+### Step 2: Resolve Refinement Targets
+
+For each concept with a `refines` string, the registry resolves it to a `ConceptId`:
+
+- **Local reference** (e.g., `ContractClause` or `legal.contracts.ContractClause`): resolved within the same package by matching against concept refs or bare concept codes.
+- **Cross-package reference** (e.g., `dep_alias->domain.ConceptCode`): the alias is looked up in the package's `dependency_aliases` map to find the target package address, then the concept is resolved in the target package.
+
+If the `refines` target cannot be resolved (unknown alias, missing concept), the registry MUST log a warning and leave the `refines` field as `null`. Unresolvable refinement targets MUST NOT prevent the concept from appearing in the graph.
+
+### Step 3: Build Pipe Nodes
+
+For every pipe in the index, the registry creates a `PipeNode` with resolved concept identities for all inputs and the output:
+
+```json
+{
+  "package_address": "github.com/acme/legal-tools",
+  "pipe_code": "extract_clause",
+  "pipe_type": "PipeLLM",
+  "domain_code": "legal.contracts",
+  "description": "Extract a specific clause from a contract document",
+  "is_exported": true,
+  "input_concept_ids": {
+    "source": {
+      "package_address": "github.com/acme/legal-tools",
+      "concept_ref": "legal.contracts.ContractDocument"
+    }
+  },
+  "output_concept_id": {
+    "package_address": "github.com/acme/legal-tools",
+    "concept_ref": "legal.contracts.ContractClause"
+  }
+}
+```
+
+Concept resolution for pipe inputs and outputs follows the same rules as refinement resolution: native concepts, local references, domain-qualified references, and cross-package references are all supported.
+
+If a pipe's output concept or any input concept cannot be resolved, the registry MUST exclude the entire pipe from the graph. Pipes with unresolvable concepts MUST NOT create dangling references.
+
+### Step 4: Build Refinement Edges
+
+For each concept node whose `refines` field is non-null, the registry creates a `REFINEMENT` edge:
+
+```json
+{
+  "kind": "refinement",
+  "source_concept_id": {
+    "package_address": "github.com/acme/legal-tools",
+    "concept_ref": "legal.contracts.NonCompeteClause"
+  },
+  "target_concept_id": {
+    "package_address": "github.com/acme/legal-tools",
+    "concept_ref": "legal.contracts.ContractClause"
+  }
+}
+```
+
+The source is the more specific concept; the target is the more general concept it refines.
+
+### Step 5: Build Data Flow Edges
+
+A data flow edge connects two pipes when the output of one can satisfy an input of the other. Compatibility is determined by the refinement hierarchy:
+
+> A pipe's output concept is compatible with another pipe's input concept if the output concept is exactly the input concept, OR the output concept is a refinement (descendant) of the input concept.
+
+The registry walks up the refinement chain from each pipe's output concept, collecting all ancestor node keys (cycle-safe). For each pipe's input, it looks up compatible producers from this reverse index.
+
+```json
+{
+  "kind": "data_flow",
+  "source_pipe_key": "github.com/acme/legal-tools::extract_pages",
+  "target_pipe_key": "github.com/acme/legal-tools::extract_clause",
+  "input_param": "source"
+}
+```
+
+Self-loops (a pipe feeding into itself) are excluded.
+
+## Index Refresh
+
+A registry MUST support at least one mechanism for keeping the index current:
+
+- **Manual trigger** — an API call or administrative action that re-indexes a specific package address.
+- **Polling** — periodic re-crawl of known package addresses, comparing the latest version tag against the indexed version.
+- **Webhook** — a Git hosting webhook (e.g., GitHub push event) that triggers re-indexing when a new tag is pushed.
+
+A registry SHOULD expose the index freshness for each package (e.g., `indexed_at` timestamp) so that clients can assess staleness.
+
+## Error Handling
+
+Indexing errors are non-fatal at the individual package and bundle level:
+
+| Error | Behavior |
+|-------|----------|
+| `METHODS.toml` missing or invalid | Skip the package. Log a warning. |
+| Individual `.mthds` file fails to parse | Skip the bundle. Index remaining bundles. Log a warning. |
+| Concept `refines` target unresolvable | Set `refines` to null. Log a warning. |
+| Pipe input/output concept unresolvable | Exclude the pipe from the graph. Log a warning. |
+| Git clone fails | Skip the package. Log a warning. |
+
+A registry MUST NOT stop its indexing run because of errors in individual packages.
+
+## See Also
+
+- [The Registry](registry.md) — API endpoints for querying the index.
+- [Registry Search](registry-search.md) — how the index and graph power type-aware queries.
+- [The Know-How Graph](../know-how-graph/index.md) — conceptual overview of the typed network.
+- [The Manifest](manifest.md) — the `METHODS.toml` fields that the registry parses.

--- a/docs/packages/registry-search.md
+++ b/docs/packages/registry-search.md
@@ -1,0 +1,186 @@
+---
+description: "Type-aware search semantics for the MTHDS registry — concept compatibility, refinement chain walking, and graph query rules."
+---
+
+# Registry Search
+
+The registry exposes two search modes: **text search** (substring matching on names and descriptions) and **type-compatible search** (signature-based queries that understand the concept refinement hierarchy). This page specifies the semantics of type-compatible search and graph queries.
+
+## Concept Compatibility
+
+Type-compatible search is built on a single rule:
+
+> An output concept is **compatible** with an input concept if the output concept is exactly the input concept, OR the output concept is a refinement (descendant) of the input concept.
+
+Compatibility is resolved by walking up the refinement chain from the output concept. If any ancestor in the chain matches the input concept, the concepts are compatible.
+
+### Example
+
+Given this refinement chain:
+
+```
+NonCompeteClause → ContractClause → Text
+```
+
+- `NonCompeteClause` is compatible with `Text` (descendant).
+- `NonCompeteClause` is compatible with `ContractClause` (direct child).
+- `NonCompeteClause` is compatible with `NonCompeteClause` (identity).
+- `Text` is NOT compatible with `NonCompeteClause` (ancestor, not descendant).
+
+The walk is cycle-safe: if a refinement chain contains a cycle (which violates the specification but can occur in malformed data), the walk terminates when a previously visited node is encountered.
+
+## Query Types
+
+### "What can I do with X?"
+
+Given a concept, find all pipes that accept it as input.
+
+A pipe accepts the concept if **any** of its input parameters expects the exact concept or an ancestor concept (i.e., the given concept is compatible with the input expectation via the refinement chain).
+
+**API:**
+
+```
+GET /v1/search/typed?accepts=Document
+```
+
+**Semantics:**
+
+For each pipe in the graph, for each input parameter:
+
+1. Resolve the `accepts` parameter to a `ConceptId`.
+2. Check if the given concept is compatible with the input concept (walk up from the given concept).
+3. If any input parameter matches, include the pipe in results.
+
+Each pipe appears at most once in the results, even if multiple input parameters match.
+
+### "What produces Y?"
+
+Given a concept, find all pipes that produce it.
+
+A pipe produces the concept if its output is the exact concept or a refinement (descendant) of the requested concept.
+
+**API:**
+
+```
+GET /v1/search/typed?produces=ContractClause
+```
+
+**Semantics:**
+
+For each pipe in the graph:
+
+1. Resolve the `produces` parameter to a `ConceptId`.
+2. Check if the pipe's output concept is compatible with the requested concept (walk up from the pipe's output).
+3. If compatible, include the pipe in results.
+
+### Combined: Accepts and Produces
+
+When both `accepts` and `produces` are specified, the registry returns pipes that satisfy both conditions simultaneously.
+
+**API:**
+
+```
+GET /v1/search/typed?accepts=Document&produces=ContractClause
+```
+
+### "I have X, I need Y" — Chain Discovery
+
+When no single pipe transforms concept X into concept Y, the registry searches for multi-step pipe chains using breadth-first search (BFS).
+
+**API:**
+
+```
+GET /v1/graph/chains?from=__native__::native.Document&to=github.com/acme/legal-tools::legal.contracts.ContractClause&max_depth=3
+```
+
+**Algorithm:**
+
+1. Find all starter pipes — those that accept the `from` concept (using "What can I do with X?" logic).
+2. Initialize a BFS queue with each starter pipe as a single-step chain.
+3. For each chain in the queue:
+    - If the last pipe's output is compatible with the `to` concept, record the chain as a result.
+    - Otherwise, if the chain has not reached `max_depth`, find all pipes that accept the last pipe's output and extend the chain.
+4. Visited pipe keys are tracked per chain to prevent cycles.
+5. Results are sorted shortest-first.
+
+The `max_depth` parameter limits the maximum number of pipes in a single chain. The default is `3`.
+
+**Example result:**
+
+A query from `native.Document` to `legal.contracts.ContractClause` might discover:
+
+```
+Chain 1 (2 steps):
+  extract_pages → extract_clause
+
+Chain 2 (3 steps):
+  extract_pages → analyze_content → extract_clause
+```
+
+### Compatibility Check
+
+Given two pipe keys, determine whether the output of the first pipe can satisfy any input of the second.
+
+**API:**
+
+```
+GET /v1/graph/compatibility?source=pkg::extract_pages&target=pkg::extract_clause
+```
+
+**Semantics:**
+
+1. Look up both pipe nodes in the graph.
+2. For each input parameter of the target pipe, check if the source pipe's output concept is compatible with the input concept.
+3. Return the list of compatible parameter names.
+
+An empty list means the pipes are incompatible.
+
+## Cross-Package Concept Resolution
+
+Type-compatible search works across package boundaries. When a concept in package A refines a concept in package B, the refinement chain spans both packages:
+
+```
+Package A:  EmploymentNDA → (refines) → Package B: NonDisclosureAgreement → (refines) → Text
+```
+
+Cross-package references are resolved during [graph construction](registry-indexing.md#step-2-resolve-refinement-targets) using the `dependency_aliases` map from `METHODS.toml`:
+
+1. The `refines` string `acme_legal->legal.contracts.NonDisclosureAgreement` is split into alias (`acme_legal`) and remainder (`legal.contracts.NonDisclosureAgreement`).
+2. The alias is resolved to a package address via the declaring package's `dependency_aliases`.
+3. The concept is looked up in the target package by `concept_ref` or by bare concept code.
+
+This resolution is transitive — a chain can span any number of packages as long as each link has a declared dependency with a valid alias.
+
+## Refinement Chain Resolution
+
+The registry exposes refinement chain information to help clients understand concept hierarchies. Given a concept, the registry walks up through `refines` links and returns the full chain:
+
+```
+[EmploymentNDA, NonDisclosureAgreement, ContractClause, Text]
+```
+
+The chain starts at the given concept and ends at the root (a concept with no `refines` link, or a native concept). The walk is cycle-safe.
+
+## Concept Identification
+
+Concepts in the graph are identified by a `ConceptId` with two components:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `package_address` | The package that defines the concept. `__native__` for native concepts. | `github.com/acme/legal-tools` |
+| `concept_ref` | Domain-qualified concept reference. | `legal.contracts.ContractClause` |
+
+The full node key is `{package_address}::{concept_ref}`.
+
+When search queries use bare concept codes (e.g., `Document` rather than `__native__::native.Document`), the registry SHOULD resolve the code by:
+
+1. Checking native concepts first.
+2. Falling back to a unique match across all indexed packages.
+3. Returning an error if the code is ambiguous (multiple packages define the same bare code).
+
+## See Also
+
+- [The Registry](registry.md) — API endpoint reference and request/response schemas.
+- [Registry Indexing](registry-indexing.md) — how the graph is constructed from package data.
+- [The Know-How Graph](../know-how-graph/index.md) — conceptual overview of typed discovery.
+- [Concepts](../language/concepts.md) — how concepts define typed data and refinement.

--- a/docs/packages/registry.md
+++ b/docs/packages/registry.md
@@ -1,0 +1,340 @@
+---
+description: "Specification of the MTHDS registry — the HTTP service that indexes packages and exposes them for discovery, type-aware search, and federated distribution."
+---
+
+# The Registry
+
+A **registry** is an HTTP service that indexes MTHDS packages and exposes them for discovery. Registries do not host package source code — they index metadata from Git-hosted packages and serve it through a structured API.
+
+## Role in the Ecosystem
+
+The [distribution model](distribution.md) separates storage from discovery:
+
+- **Storage** remains decentralized — packages live in Git repositories controlled by their authors.
+- **Discovery** is centralized per registry — a registry crawls known package addresses, builds an index, constructs the [Know-How Graph](../know-how-graph/index.md), and serves queries over HTTP.
+
+Multiple registries can coexist. A client can query several registries in order (analogous to Go's `GOPROXY` chain), falling back from one to the next.
+
+## API Versioning
+
+All endpoints are prefixed with `/v1/`. The version number increments only for breaking changes. Non-breaking additions (new optional fields, new endpoints) do not require a version bump.
+
+```
+https://registry.example.com/v1/packages
+```
+
+## Endpoints
+
+### List Packages
+
+```
+GET /v1/packages?offset=0&limit=20
+```
+
+Returns a paginated list of indexed packages.
+
+**Response:**
+
+```json
+{
+  "items": [
+    {
+      "address": "github.com/acme/legal-tools",
+      "version": "1.2.0",
+      "description": "Contract analysis and clause extraction methods",
+      "authors": ["Acme Legal Team"],
+      "license": "Apache-2.0",
+      "domains": [
+        { "domain_code": "legal.contracts", "description": "Contract processing domain" }
+      ],
+      "concept_count": 5,
+      "pipe_count": 8,
+      "dependency_count": 2
+    }
+  ],
+  "total": 47,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+### Get Package Detail
+
+```
+GET /v1/packages/{address}
+```
+
+The `{address}` path parameter is the full package address, URL-encoded where necessary (e.g., `github.com%2Facme%2Flegal-tools`).
+
+Returns the full `PackageIndexEntry` for a single package.
+
+**Response:**
+
+```json
+{
+  "address": "github.com/acme/legal-tools",
+  "version": "1.2.0",
+  "description": "Contract analysis and clause extraction methods",
+  "authors": ["Acme Legal Team"],
+  "license": "Apache-2.0",
+  "domains": [
+    { "domain_code": "legal.contracts", "description": "Contract processing domain" }
+  ],
+  "concepts": [
+    {
+      "concept_code": "ContractClause",
+      "domain_code": "legal.contracts",
+      "concept_ref": "legal.contracts.ContractClause",
+      "description": "A single clause extracted from a contract",
+      "refines": "native.Text",
+      "structure_fields": ["clause_type", "text", "section_number"]
+    }
+  ],
+  "pipes": [
+    {
+      "pipe_code": "extract_clause",
+      "pipe_type": "PipeLLM",
+      "domain_code": "legal.contracts",
+      "description": "Extract a specific clause from a contract document",
+      "input_specs": { "source": "ContractDocument" },
+      "output_spec": "ContractClause",
+      "is_exported": true
+    }
+  ],
+  "dependencies": ["github.com/mthds/document-processing"],
+  "dependency_aliases": { "doc_processing": "github.com/mthds/document-processing" }
+}
+```
+
+### Text Search
+
+```
+GET /v1/search?q=contract&type=concept&domain=legal.contracts&offset=0&limit=20
+```
+
+**Query parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `q` | Yes | Search term. Case-insensitive substring match against concept codes, pipe codes, descriptions, and domain codes. |
+| `type` | No | Filter by entity type: `concept`, `pipe`, or omit for both. |
+| `domain` | No | Filter results to a specific domain code. |
+| `offset` | No | Pagination offset. Default: `0`. |
+| `limit` | No | Page size. Default: `20`. Maximum: `100`. |
+
+**Response:**
+
+```json
+{
+  "items": [
+    {
+      "kind": "concept",
+      "package_address": "github.com/acme/legal-tools",
+      "concept_code": "ContractClause",
+      "domain_code": "legal.contracts",
+      "description": "A single clause extracted from a contract",
+      "refines": "native.Text"
+    },
+    {
+      "kind": "pipe",
+      "package_address": "github.com/acme/legal-tools",
+      "pipe_code": "extract_clause",
+      "pipe_type": "PipeLLM",
+      "domain_code": "legal.contracts",
+      "description": "Extract a specific clause from a contract document",
+      "input_specs": { "source": "ContractDocument" },
+      "output_spec": "ContractClause",
+      "is_exported": true
+    }
+  ],
+  "total": 2,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+### Type-Compatible Search
+
+```
+GET /v1/search/typed?accepts=Document&produces=ContractClause
+```
+
+Finds pipes by their typed signatures, using the [Know-How Graph](../know-how-graph/index.md) to resolve concept compatibility through refinement chains.
+
+**Query parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `accepts` | No | Concept code or reference. Finds pipes that accept this concept as input (including concepts that this one refines). |
+| `produces` | No | Concept code or reference. Finds pipes that produce this concept as output (including concepts that refine this one). |
+| `offset` | No | Pagination offset. Default: `0`. |
+| `limit` | No | Page size. Default: `20`. Maximum: `100`. |
+
+At least one of `accepts` or `produces` MUST be provided.
+
+**Response:**
+
+```json
+{
+  "items": [
+    {
+      "package_address": "github.com/acme/legal-tools",
+      "pipe_code": "extract_clause",
+      "pipe_type": "PipeLLM",
+      "domain_code": "legal.contracts",
+      "description": "Extract a specific clause from a contract document",
+      "input_specs": { "source": "ContractDocument" },
+      "output_spec": "ContractClause",
+      "is_exported": true
+    }
+  ],
+  "total": 1,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+### Graph Chain Query
+
+```
+GET /v1/graph/chains?from={concept_id}&to={concept_id}&max_depth=3
+```
+
+Finds multi-step pipe chains that transform one concept into another, using BFS traversal of the Know-How Graph.
+
+**Query parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `from` | Yes | Source concept ID in `package_address::concept_ref` format (e.g., `__native__::native.Document`). |
+| `to` | Yes | Target concept ID in `package_address::concept_ref` format. |
+| `max_depth` | No | Maximum number of pipes in a chain. Default: `3`. |
+
+**Response:**
+
+```json
+{
+  "chains": [
+    {
+      "steps": [
+        {
+          "pipe_key": "github.com/acme/legal-tools::extract_pages",
+          "pipe_code": "extract_pages",
+          "package_address": "github.com/acme/legal-tools",
+          "input_specs": { "source": "Document" },
+          "output_spec": "PageContent"
+        },
+        {
+          "pipe_key": "github.com/acme/legal-tools::extract_clause",
+          "pipe_code": "extract_clause",
+          "package_address": "github.com/acme/legal-tools",
+          "input_specs": { "source": "PageContent" },
+          "output_spec": "ContractClause"
+        }
+      ]
+    }
+  ],
+  "from": "__native__::native.Document",
+  "to": "github.com/acme/legal-tools::legal.contracts.ContractClause"
+}
+```
+
+Chains are sorted shortest-first. If no chain exists within `max_depth`, the `chains` array is empty.
+
+### Compatibility Check
+
+```
+GET /v1/graph/compatibility?source={pipe_key}&target={pipe_key}
+```
+
+Checks whether the output of one pipe is type-compatible with an input of another.
+
+**Query parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `source` | Yes | Source pipe key in `package_address::pipe_code` format. |
+| `target` | Yes | Target pipe key in `package_address::pipe_code` format. |
+
+**Response:**
+
+```json
+{
+  "compatible": true,
+  "compatible_params": ["source"],
+  "source_output": "ContractClause",
+  "target_inputs": { "source": "Text", "context": "AnalysisContext" }
+}
+```
+
+The `compatible_params` array lists the target pipe's input parameter names that can accept the source pipe's output. An empty array means the pipes are incompatible.
+
+## Pagination
+
+All list endpoints use offset-based pagination:
+
+| Field | Description |
+|-------|-------------|
+| `offset` | Number of items to skip. Default: `0`. |
+| `limit` | Maximum items per page. Default: `20`. Maximum: `100`. |
+| `total` | Total number of matching items (returned in every response). |
+
+A registry MUST return a `total` field in paginated responses. Clients SHOULD use `total` to determine whether more pages exist.
+
+## Authentication
+
+A registry MAY require authentication. When authentication is required:
+
+- The registry MUST accept a Bearer token in the `Authorization` header.
+- The registry MUST return `401 Unauthorized` for requests that require authentication but lack a valid token.
+- The registry MUST return `403 Forbidden` for requests with a valid token that lacks the required scope.
+
+```
+Authorization: Bearer <token>
+```
+
+Token provisioning is outside the scope of this specification. Registries may use API keys, OAuth tokens, or any scheme that produces a Bearer token.
+
+## Rate Limiting
+
+A registry SHOULD enforce rate limits to ensure fair use. When rate-limited:
+
+- The registry MUST return `429 Too Many Requests`.
+- The registry SHOULD include a `Retry-After` header with the number of seconds to wait.
+
+## Error Format
+
+All error responses use a consistent JSON format:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Package 'github.com/acme/unknown' is not indexed by this registry."
+  }
+}
+```
+
+**Standard error codes:**
+
+| HTTP Status | Error Code | Description |
+|-------------|------------|-------------|
+| `400` | `bad_request` | Malformed query parameters or missing required fields. |
+| `401` | `unauthorized` | Missing or invalid authentication token. |
+| `403` | `forbidden` | Valid token but insufficient permissions. |
+| `404` | `not_found` | Package or resource not found in the index. |
+| `422` | `invalid_concept` | Concept ID format is invalid or concept not found in the graph. |
+| `429` | `rate_limited` | Too many requests. |
+| `500` | `internal_error` | Unexpected server error. |
+
+## Content Type
+
+All responses use `Content-Type: application/json; charset=utf-8`. A registry MUST return JSON for all API endpoints. A registry MUST set the `Content-Type` header on every response.
+
+## See Also
+
+- [Registry Indexing](registry-indexing.md) — how registries crawl and index packages.
+- [Registry Search](registry-search.md) — type-aware search semantics and graph query rules.
+- [Registry Distribution Protocol](registry-distribution.md) — proxy chains, signed manifests, and multi-tier deployment.
+- [Distribution](distribution.md) — the federated model that registries build upon.
+- [The Know-How Graph](../know-how-graph/index.md) — the typed network that powers registry search.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,10 @@ plugins:
         - packages/distribution.md: "Distribution"
         - packages/version-resolution.md: "Version Resolution"
         - know-how-graph/index.md: "The Know-How Graph"
+        - packages/registry.md: "The Registry"
+        - packages/registry-indexing.md: "Registry Indexing"
+        - packages/registry-search.md: "Registry Search"
+        - packages/registry-distribution.md: "Registry Distribution Protocol"
         Reference:
         - spec/mthds-format.md: ".mthds File Format"
         - spec/manifest-format.md: "METHODS.toml Format"
@@ -161,6 +165,11 @@ nav:
     - Distribution: packages/distribution.md
     - Version Resolution: packages/version-resolution.md
     - The Know-How Graph: know-how-graph/index.md
+    - The Registry:
+      - Registry Overview: packages/registry.md
+      - Registry Indexing: packages/registry-indexing.md
+      - Registry Search: packages/registry-search.md
+      - Registry Distribution Protocol: packages/registry-distribution.md
   - Reference:
     - Specification:
       - .mthds File Format: spec/mthds-format.md


### PR DESCRIPTION
## Summary

- Add four new documentation pages covering the MTHDS Registry layer: overview & API contract, indexing pipeline & Know-How Graph construction, type-aware search semantics, and distribution protocol (proxy chains, signed manifests, multi-tier deployment)
- Update `mkdocs.yml` nav and `llmstxt-md` sections to include the new pages under "The Registry" subsection of "The Package System"
- Add cross-reference links from existing pages (distribution, know-how-graph, publish-package, discover-methods) to the new registry pages

## Test plan

- [x] `make docs-check` passes (strict MkDocs build with no warnings)
- [ ] Verify new pages render correctly in the local dev server (`make docs`)
- [ ] Verify navigation tabs and sidebar sections display the new "The Registry" subsection
- [ ] Verify all cross-reference links resolve correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new pages and nav/link updates) with no runtime or data-handling impact; primary risk is broken links or doc build/navigation issues.
> 
> **Overview**
> Adds a new **Registry** documentation section describing the MTHDS registry layer: an HTTP API for package discovery, the registry indexing pipeline/Know-How Graph construction, type-aware search semantics (including chain discovery/compatibility), and a distribution protocol covering proxy chains, signed manifests, social signals, and publish notifications.
> 
> Updates `mkdocs.yml` navigation and `llmstxt-md` sections to surface these pages, and adds cross-links from existing guides (`discover-methods`, `publish-package`) and conceptual docs (`know-how-graph`, `distribution`) to the new registry specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e5516f3256b2b558d31ca6dbf160a40b3e73ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->