### PR TITLE
Release v0.0.3

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release
-description: Prepare a new release for the MTHDS project. Bumps version in pyproject.toml, updates CHANGELOG.md, manages the release/vX.Y.Z branch, validates docs build, and commits. Use when the user says "release", "prepare a release", "bump version", "new version", or "cut a release".
+description: Prepare a new release for the MTHDS project. Bumps version in pyproject.toml, syncs uv.lock, updates CHANGELOG.md, manages the release/vX.Y.Z branch, validates docs build, and commits. Use when the user says "release", "prepare a release", "bump version", "new version", or "cut a release".
 ---
 
 # Release Workflow
 
-Guides the user through preparing a new MTHDS release in 7 interactive steps. Every step requires explicit user confirmation before proceeding.
+Guides the user through preparing a new MTHDS release in 8 interactive steps. Every step requires explicit user confirmation before proceeding.
 
 ## Step 1 — Gather State
 
@@ -47,7 +47,20 @@ Edit the `version = "..."` line in `pyproject.toml` to `version = "{TARGET_VERSI
 
 The version in pyproject.toml must **not** have a `v` prefix (e.g. `0.0.4`, not `v0.0.4`).
 
-## Step 5 — Update CHANGELOG.md
+## Step 5 — Sync uv.lock
+
+After updating `pyproject.toml`, regenerate the lock file so it reflects `TARGET_VERSION`:
+
+```bash
+uv lock
+```
+
+Verify the output confirms the version was updated (e.g. `Updated mthds vX.Y.Z -> v{TARGET_VERSION}`).
+
+- **If the lock file was already in sync**: inform the user and continue.
+- **On failure**: show the error and ask the user how to proceed.
+
+## Step 6 — Update CHANGELOG.md
 
 The changelog entry **must** match the CI grep pattern: `## [vX.Y.Z] -`
 
@@ -66,7 +79,7 @@ The user may accept, edit, or rewrite the proposed entry.
 
 - **If exists**: show the existing entry and ask the user whether to keep it or edit it.
 
-## Step 6 — Validate Docs Build
+## Step 7 — Validate Docs Build
 
 Run:
 
@@ -77,18 +90,18 @@ make docs-check
 - **On success**: report and continue.
 - **On failure**: show the errors and ask the user how to proceed (fix issues, skip validation, or abort).
 
-## Step 7 — Review & Commit
+## Step 8 — Review & Commit
 
 Present a full summary:
 
 - Target version: `v{TARGET_VERSION}`
 - Branch: `release/v{TARGET_VERSION}`
-- Files changed: `pyproject.toml`, `CHANGELOG.md`
+- Files changed: `pyproject.toml`, `uv.lock`, `CHANGELOG.md`
 - Changelog entry preview
 
 Ask the user to confirm. On confirmation:
 
-1. Stage **only** `pyproject.toml` and `CHANGELOG.md` — never use `git add .` or `git add -A`.
+1. Stage **only** `pyproject.toml`, `uv.lock`, and `CHANGELOG.md` — never use `git add .` or `git add -A`.
 2. Commit with message: `Bump version to {TARGET_VERSION} and update changelog`
 3. Show the commit result.
 
@@ -101,7 +114,7 @@ Wait for explicit user approval before pushing or creating a PR.
 
 ## Rules
 
-- Never use `git add .` or `git add -A` — only stage `pyproject.toml` and `CHANGELOG.md`.
+- Never use `git add .` or `git add -A` — only stage `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`.
 - Never push or create PRs without explicit user approval.
 - The `v` prefix appears in branch names and changelog headers, but **not** in `pyproject.toml`.
 - Always use today's date for new changelog entries (format: `YYYY-MM-DD`).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: release
+description: Prepare a new release for the MTHDS project. Bumps version in pyproject.toml, updates CHANGELOG.md, manages the release/vX.Y.Z branch, validates docs build, and commits. Use when the user says "release", "prepare a release", "bump version", "new version", or "cut a release".
+---
+
+# Release Workflow
+
+Guides the user through preparing a new MTHDS release in 7 interactive steps. Every step requires explicit user confirmation before proceeding.
+
+## Step 1 — Gather State
+
+Read the following and present a summary:
+
+1. Current version from `pyproject.toml` (`version = "X.Y.Z"`)
+2. Latest entry in `CHANGELOG.md`
+3. Current git branch (`git branch --show-current`)
+4. Working tree status (`git status --short`)
+
+If the working tree is dirty, **warn the user** and ask whether to continue or abort.
+
+## Step 2 — Determine Target Version
+
+Calculate the three semver bump options from the current version:
+
+- **Patch**: `X.Y.Z+1`
+- **Minor**: `X.Y+1.0`
+- **Major**: `X+1.0.0`
+
+Present these options to the user using `AskUserQuestion`. If the current branch already looks like `release/vA.B.C` and the version in `pyproject.toml` was already bumped, offer a **"Keep current (A.B.C)"** option.
+
+Store the chosen version as `TARGET_VERSION` (no `v` prefix, e.g. `0.0.4`).
+
+## Step 3 — Branch Management
+
+The release branch **must** be named `release/v{TARGET_VERSION}` (CI regex: `^release/v[0-9]+\.[0-9]+\.[0-9]+$`).
+
+- If already on the correct branch: inform the user and continue.
+- If on `main` or another branch: confirm with the user, then create and switch to `release/v{TARGET_VERSION}`.
+- If on a *different* release branch: warn the user and ask how to proceed.
+
+## Step 4 — Update Version in pyproject.toml
+
+Edit the `version = "..."` line in `pyproject.toml` to `version = "{TARGET_VERSION}"`.
+
+- If the version already matches: inform the user and skip.
+- Otherwise: use the Edit tool to make the change, then show the diff.
+
+The version in pyproject.toml must **not** have a `v` prefix (e.g. `0.0.4`, not `v0.0.4`).
+
+## Step 5 — Update CHANGELOG.md
+
+The changelog entry **must** match the CI grep pattern: `## [vX.Y.Z] -`
+
+Check if `CHANGELOG.md` already contains a `## [v{TARGET_VERSION}] -` entry.
+
+- **If missing**: run `git log main..HEAD --oneline` (or `git log --oneline -20` if on `main`) to review recent commits. Draft a changelog entry from those commits and propose it to the user for approval. Insert the approved entry at the top of the changelog (after the `# Changelog` heading) formatted as:
+
+```markdown
+## [v{TARGET_VERSION}] - {TODAY'S DATE in YYYY-MM-DD}
+
+- Item one
+- Item two
+```
+
+The user may accept, edit, or rewrite the proposed entry.
+
+- **If exists**: show the existing entry and ask the user whether to keep it or edit it.
+
+## Step 6 — Validate Docs Build
+
+Run:
+
+```bash
+make docs-check
+```
+
+- **On success**: report and continue.
+- **On failure**: show the errors and ask the user how to proceed (fix issues, skip validation, or abort).
+
+## Step 7 — Review & Commit
+
+Present a full summary:
+
+- Target version: `v{TARGET_VERSION}`
+- Branch: `release/v{TARGET_VERSION}`
+- Files changed: `pyproject.toml`, `CHANGELOG.md`
+- Changelog entry preview
+
+Ask the user to confirm. On confirmation:
+
+1. Stage **only** `pyproject.toml` and `CHANGELOG.md` — never use `git add .` or `git add -A`.
+2. Commit with message: `Bump version to {TARGET_VERSION} and update changelog`
+3. Show the commit result.
+
+Then offer (but do not automatically execute):
+
+- **Push** the branch to origin (`git push -u origin release/v{TARGET_VERSION}`)
+- **Create a PR** to `main` using `gh pr create`
+
+Wait for explicit user approval before pushing or creating a PR.
+
+## Rules
+
+- Never use `git add .` or `git add -A` — only stage `pyproject.toml` and `CHANGELOG.md`.
+- Never push or create PRs without explicit user approval.
+- The `v` prefix appears in branch names and changelog headers, but **not** in `pyproject.toml`.
+- Always use today's date for new changelog entries (format: `YYYY-MM-DD`).
+- If any step fails or the user wants to abort, stop immediately — do not continue the workflow.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ site/
 
 # temp
 temp/
+
+# skill build artifacts
+*.skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.0.3] - 2026-02-20
+
+- Renamed Home section first page to Overview
+- Quieted check-uv and env targets for operational commands
+- Refined project description
+- Added /release skill and gitignore .skill artifacts
+
 ## [v0.0.2] - 2026-02-19
 
 - Polished documentation

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ endef
 export HELP
 
 .PHONY: \
-	all help env lock install update \
+	all help env env-verbose lock install update \
 	cleanderived cleanenv cleanall reinstall ri \
 	docs docs-check docs-serve-versioned docs-list \
 	docs-deploy docs-deploy-stable docs-deploy-specific-version docs-deploy-root docs-delete \
-	li check-uv
+	li check-uv check-uv-verbose
 
 all help:
 	@echo "$$HELP"
@@ -102,6 +102,13 @@ all help:
 ##########################################################################################
 
 check-uv:
+	@command -v uv >/dev/null 2>&1 || { \
+		echo "uv not found – installing latest …"; \
+		curl -LsSf https://astral.sh/uv/install.sh | sh; \
+	}
+	@uv self update >/dev/null 2>&1 || true
+
+check-uv-verbose:
 	$(call PRINT_TITLE,"Ensuring uv ≥ $(UV_MIN_VERSION)")
 	@command -v uv >/dev/null 2>&1 || { \
 		echo "uv not found – installing latest …"; \
@@ -110,6 +117,12 @@ check-uv:
 	@uv self update >/dev/null 2>&1 || true
 
 env: check-uv
+	@if [ ! -d $(VIRTUAL_ENV) ]; then \
+		echo "Creating Python virtual env in \`${VIRTUAL_ENV}\`"; \
+		uv venv $(VIRTUAL_ENV) --python $(PYTHON_VERSION); \
+	fi
+
+env-verbose: check-uv-verbose
 	$(call PRINT_TITLE,"Creating virtual environment")
 	@if [ ! -d $(VIRTUAL_ENV) ]; then \
 		echo "Creating Python virtual env in \`${VIRTUAL_ENV}\`"; \
@@ -118,7 +131,7 @@ env: check-uv
 		echo "Python virtual env already exists in \`${VIRTUAL_ENV}\`"; \
 	fi
 
-install: env
+install: env-verbose
 	$(call PRINT_TITLE,"Installing dependencies")
 	@. $(VIRTUAL_ENV)/bin/activate && \
 	uv sync && \
@@ -129,7 +142,7 @@ lock: env
 	@uv lock && \
 	echo "uv lock without update";
 
-update: env
+update: env-verbose
 	$(call PRINT_TITLE,"Updating all dependencies")
 	@uv lock --upgrade && \
 	uv sync && \

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 description: "MTHDS is an open standard for defining, packaging, and sharing AI methods — giving agents the ability to discover and execute structured, composable AI workflows."
 ---
 
-# Home
+# Overview
 
 MTHDS is an open standard for defining, packaging, and distributing AI methods. It provides a typed language for describing what an AI should do, with what inputs, and what outputs to produce — all in plain-text files that humans and machines can read alike.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ plugins:
   - llmstxt-md:
       sections:
         Home:
-        - index.md: "Introduction to MTHDS"
+        - index.md: "Overview"
         - what-is-mthds/index.md: "What is MTHDS?"
         - about/philosophy.md: "Design Philosophy"
         - about/comparison-agent-skills.md: "Comparison with Agent Skills"
@@ -142,7 +142,7 @@ extra_css:
 
 nav:
   - Home:
-    - Home: index.md
+    - Overview: index.md
     - What is MTHDS?: what-is-mthds/index.md
     - Design Philosophy: about/philosophy.md
     - Comparison with Agent Skills: about/comparison-agent-skills.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mthds"
-version = "0.0.2"
-description = "Methods are an open standard for creating and sharing AI methods."
+version = "0.0.3"
+description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.0.2"
+version = "0.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.0.1"
+version = "0.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary
- Bump version from 0.0.2 to 0.0.3
- Refine project description to "MTHDS is the open standard for creating and sharing executable, composable AI methods."
- Sync uv.lock

## Test plan
- [ ] Verify `pyproject.toml` version is correct
- [ ] Verify `uv.lock` is in sync
- [ ] Confirm docs build passes (`make docs-check`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily versioning, documentation/nav text, and Makefile verbosity tweaks with no runtime logic changes.
> 
> **Overview**
> Prepares the `v0.0.3` release by bumping `pyproject.toml` from `0.0.2` to `0.0.3`, syncing `uv.lock`, and adding a `CHANGELOG.md` entry for `v0.0.3`.
> 
> Refines project/docs wording by renaming the docs landing page from *Home* to *Overview* (`docs/index.md`, `mkdocs.yml`) and updating the project description.
> 
> Adjusts the `Makefile` to add quiet vs verbose setup targets (`check-uv-verbose`, `env-verbose`) and to route `install`/`update` through the verbose path, and updates `.gitignore` to exclude `*.skill` artifacts while adding a new `.claude/skills/release` workflow document.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e762db76b9d51a0bea30e558129f67d6120fcf99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->