### PR TITLE
deploy

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,20 +3,20 @@
 
 {% block extrahead %}
 {{ super() }} {# keep anything Material already outputs #}
-{% if page and page.title and page.meta %}
-{% set og_image = page.meta.image | default(config.site_url ~ "images/og-banner.jpeg") %}
-<meta property="og:type" content="article">
-<meta property="og:title" content="{{ page.meta.title or page.title }}">
-<meta property="og:description" content="{{ page.meta.description or config.site_description }}">
+{% set og_title = (page.meta.title if page and page.meta and page.meta.title) or (page.title if page and page.title) or config.site_name %}
+{% set og_desc = (page.meta.description if page and page.meta and page.meta.description) or config.site_description %}
+{% set og_image = (page.meta.image if page and page.meta and page.meta.image) or (config.site_url ~ "images/og-banner.jpeg") %}
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{ og_title }}">
+<meta property="og:description" content="{{ og_desc }}">
 <meta property="og:image" content="{{ og_image }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta property="og:url" content="{{ page.canonical_url }}">
+<meta property="og:url" content="{{ page.canonical_url if page else config.site_url }}">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ page.meta.title or page.title }}">
-<meta name="twitter:description" content="{{ page.meta.description or config.site_description }}">
+<meta name="twitter:title" content="{{ og_title }}">
+<meta name="twitter:description" content="{{ og_desc }}">
 <meta name="twitter:image" content="{{ og_image }}">
-{% endif %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened social meta tags in the docs theme so shared links consistently show the correct title, description, and banner image, even when a page lacks front‑matter.

- **Bug Fixes**
  - Compute og_title, og_desc, og_image with safe fallbacks to config.
  - Set og:type to website and fallback og:url to site_url when page is missing.
  - Remove conditional wrapper so OG/Twitter tags render on all pages.

<sup>Written for commit f6232c6240929df911dc6c1a38bc2cb76bbb0aea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

