### PR TITLE
update og-banner

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,9 +3,11 @@
 
 {% block extrahead %}
 {{ super() }} {# keep anything Material already outputs #}
+{# Ensure base URL always ends with / (mike strips trailing slash on versioned deploys) #}
+{% set base_url = config.site_url ~ ('' if config.site_url[-1:] == '/' else '/') %}
 {% set og_title = (page.meta.title if page and page.meta and page.meta.title) or (page.title if page and page.title) or config.site_name %}
 {% set og_desc = (page.meta.description if page and page.meta and page.meta.description) or config.site_description %}
-{% set og_image = (page.meta.image if page and page.meta and page.meta.image) or (config.site_url ~ "images/og-banner.jpeg") %}
+{% set og_image = (page.meta.image if page and page.meta and page.meta.image) or (base_url ~ "images/og-banner.jpeg") %}
 <meta property="og:type" content="website">
 <meta property="og:title" content="{{ og_title }}">
 <meta property="og:description" content="{{ og_desc }}">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure base URL always has a trailing slash and use it for og:image in the docs template. This prevents broken Open Graph banner images on versioned builds where mike strips the slash.

<sup>Written for commit a1913a351ee3334116c0aadc95fc043bf737f829. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

