### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.1.3] - 2026-02-26
+
+- Add PostHog analytics to docs site
+- Add Hub link to navigation
+
 ## [v0.1.2] - 2026-02-26
 
 - Update homepage with overview content

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -37,4 +37,12 @@
   "url": "https://mthds.ai"
 }
 </script>
+<!-- PostHog analytics -->
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once unregister opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing identify alias people.set people.set_once set_config reset get_distinct_id getFeatureFlag getFeatureFlagPayload isFeatureEnabled onFeatureFlags reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_LRwe2lybfPTNCzAT1ScpnsWznrxAvmc1pmCaXEr1hwJ', {
+    api_host: 'https://eu.i.posthog.com',
+    person_profiles: 'identified_only'
+  });
+</script>
 {% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,3 +201,4 @@ nav:
     - Code of Conduct: CODE_OF_CONDUCT.md
     - License: license.md
     - Changelog: changelog.md
+  - "Hub \u2197": https://mthds.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.1.2"
+version = "0.1.3"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

- Add PostHog analytics to docs site
- Add Hub link to navigation

## Release checklist

- [x] Version bumped in `pyproject.toml`
- [x] `uv.lock` synced
- [x] `CHANGELOG.md` updated
- [x] Docs build passes (`make docs-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds third-party analytics JS to the docs site, which can impact privacy/compliance and page performance; the remaining changes are straightforward version/nav updates.
> 
> **Overview**
> **Release v0.1.3.** Adds PostHog analytics to the MkDocs docs site by injecting the PostHog init snippet into `docs/overrides/main.html`.
> 
> Updates MkDocs navigation to include an external **Hub** link, and bumps the project version to `0.1.3` with corresponding `CHANGELOG.md` entry and `uv.lock` sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec05024f3db7a1910c4200c5a1fcd5f31ae3c3ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostHog analytics to the docs site (EU instance with anonymous pageview auto-capture) and adds a “Hub ↗” external link in the navigation. Bumps version to 0.1.3 and updates the changelog.

<sup>Written for commit ec05024f3db7a1910c4200c5a1fcd5f31ae3c3ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

