### PR TITLE
open github link in another tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ venv/
 # mkdocs build output
 site/
 
+# mkdocs privacy plugin cache
+.cache/
+
 # temp
 temp/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ The `mkdocs.yml` configures specific plugins and markdown extensions. Use these 
 | `search` | Full-text search |
 | `meta-manager` | Default metadata from `.meta.yml` files |
 | `glightbox` | Lightbox for images (click to zoom) |
+| `privacy` | Downloads external assets locally (GDPR) and applies `links_attr_map` (e.g., `target: _blank` on external links) |
 | `llmstxt-md` | Generates `llms.txt` for LLM-friendly content — nav sections must be updated when adding pages |
 
 ### Theme Features (from `mkdocs.yml` theme config)
@@ -104,6 +105,10 @@ The `mkdocs.yml` configures specific plugins and markdown extensions. Use these 
 - After making changes, always run `make docs-check` to verify the build passes with `--strict`
 - When adding or moving pages, update BOTH the `nav:` section AND the `llmstxt-md` plugin `sections:` in `mkdocs.yml`
 - `make docs-check` runs `mkdocs build --strict` — any warning (broken links, missing nav targets) becomes a build error
+
+## General Rules
+
+- **Do not reinvent the wheel.** Before writing custom JS, CSS, or template overrides, always search for an existing MkDocs plugin or Material theme feature that solves the problem. Only write custom code if no plugin or built-in option exists.
 
 ## Existing Files (do not overwrite)
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -45,4 +45,26 @@
     person_profiles: 'identified_only'
   });
 </script>
+<!-- Open all external links in a new tab -->
+<script>
+  function openExternalLinksInNewTab() {
+    document.querySelectorAll("a[href^='http']").forEach(function (a) {
+      if (a.hostname !== window.location.hostname) {
+        a.setAttribute("target", "_blank");
+        a.setAttribute("rel", "noopener");
+      }
+    });
+  }
+  document.addEventListener("DOMContentLoaded", openExternalLinksInNewTab);
+  document.addEventListener("DOMContentSwitch", openExternalLinksInNewTab);
+
+  // MkDocs Material instant navigation: re-run after each page load
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(openExternalLinksInNewTab);
+  } else {
+    // Fallback: observe DOM changes for instant navigation
+    new MutationObserver(openExternalLinksInNewTab)
+      .observe(document.body, { childList: true, subtree: true });
+  }
+</script>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -45,26 +45,5 @@
     person_profiles: 'identified_only'
   });
 </script>
-<!-- Open all external links in a new tab -->
-<script>
-  function openExternalLinksInNewTab() {
-    document.querySelectorAll("a[href^='http']").forEach(function (a) {
-      if (a.hostname !== window.location.hostname) {
-        a.setAttribute("target", "_blank");
-        a.setAttribute("rel", "noopener");
-      }
-    });
-  }
-  document.addEventListener("DOMContentLoaded", openExternalLinksInNewTab);
-  document.addEventListener("DOMContentSwitch", openExternalLinksInNewTab);
 
-  // MkDocs Material instant navigation: re-run after each page load
-  if (typeof document$ !== "undefined") {
-    document$.subscribe(openExternalLinksInNewTab);
-  } else {
-    // Fallback: observe DOM changes for instant navigation
-    new MutationObserver(openExternalLinksInNewTab)
-      .observe(document.body, { childList: true, subtree: true });
-  }
-</script>
 {% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,9 @@ extra:
 
 plugins:
   - search
+  - privacy:
+      links_attr_map:
+        target: _blank
   - meta-manager
   - glightbox:
       touchNavigation: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Open all external links in the docs (including GitHub) in a new tab so readers keep their place. Uses the MkDocs Privacy plugin to set target=_blank on external links and download external assets locally; adds .cache to .gitignore.

<sup>Written for commit 41b90baeb1e0d2e612460193dad7e7e563e4be6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

