### PR TITLE
feature/snake-case-method-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.1.4] - 2026-03-02
+
+### Changed
+
+- **Method names: strict snake_case** — the `name` field specification updated from kebab-case to snake_case (pattern `[a-z][a-z0-9_]*`). Directory name must match the `name` field exactly — no conversion needed.
+- Updated CLI I/O contract examples to use snake_case method names.
+
 ## [v0.1.3] - 2026-02-26
 
 - Add PostHog analytics to docs site

--- a/docs/packages/manifest.md
+++ b/docs/packages/manifest.md
@@ -10,7 +10,7 @@ description: "Reference for METHODS.toml — the MTHDS package manifest that dec
 
 ```toml
 [package]
-name          = "nda-analyzer"
+name          = "nda_analyzer"
 address       = "github.com/acme/legal-tools"
 display_name  = "Nda Analyzer"
 version       = "0.3.0"
@@ -30,7 +30,7 @@ pipes = ["extract_clause", "analyze_nda", "compare_contracts"]
 pipes = ["compute_weighted_score"]
 ```
 
-This manifest declares a method called `nda-analyzer` hosted at `github.com/acme/legal-tools`, version `0.3.0`. It exports specific pipes from three domains and designates `analyze_nda` as its main entry point.
+This manifest declares a method called `nda_analyzer` hosted at `github.com/acme/legal-tools`, version `0.3.0`. It exports specific pipes from three domains and designates `analyze_nda` as its main entry point.
 
 ## The `[package]` Section
 
@@ -38,7 +38,7 @@ The `[package]` section defines the package's identity:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | The name of the method. Must be `kebab-case` (matching `[a-z][a-z0-9]*(-[a-z0-9]+)*`), max 25 characters. |
+| `name` | Yes | The name of the method. Must be `snake_case` (matching `[a-z][a-z0-9_]*`), 2-25 characters. The package directory name must match the `name` field exactly. |
 | `address` | Yes | Globally unique identifier. Must follow the hostname/path pattern (e.g., `github.com/org/repo`). |
 | `display_name` | No | Human-friendly label for CLI output and registry listings. Cosmetic only — never used as an identifier. Max 128 characters. |
 | `version` | Yes | [Semantic version](https://semver.org/) (`MAJOR.MINOR.PATCH`, with optional pre-release and build metadata). |
@@ -84,7 +84,7 @@ Examples: `1.0.0`, `0.3.0`, `2.1.3-beta.1`, `1.0.0-rc.1+build.42`
 The `main_pipe` field designates the package's primary entry point — the pipe that runs when a user invokes the package by slug or address:
 
 ```bash
-mthds run method nda-analyzer
+mthds run method nda_analyzer
 mthds run method github.com/acme/legal-tools
 ```
 

--- a/docs/packages/structure.md
+++ b/docs/packages/structure.md
@@ -9,7 +9,7 @@ A **package** is the distribution unit of MTHDS. It is a directory that contains
 ## A Minimal Package
 
 ```
-my-tool/
+my_tool/
 ├── METHODS.toml
 └── main.mthds
 ```
@@ -19,7 +19,7 @@ This is the smallest distributable package: one manifest, one bundle. The manife
 ## A Full Package
 
 ```
-legal-tools/
+legal_tools/
 ├── METHODS.toml
 ├── methods.lock
 ├── general_legal.mthds

--- a/docs/spec/cli-io-contract.md
+++ b/docs/spec/cli-io-contract.md
@@ -95,17 +95,17 @@ The `--inputs` / `-i` flag accepts a file path or inline JSON string. If the val
 
 ```bash
 # Inline JSON
-mthds-agent pipelex run method my-method --inputs '{"text": {"concept": "native.Text", "content": {"text": "hello"}}}'
+mthds-agent pipelex run method my_method --inputs '{"text": {"concept": "native.Text", "content": {"text": "hello"}}}'
 
 # File path
-mthds-agent pipelex run method my-method --inputs data.json
+mthds-agent pipelex run method my_method --inputs data.json
 ```
 
 When a method is installed as a CLI shim (see [CLI Reference](../cli/index.md)), the same commands are available as:
 
 ```bash
-my-method --inputs '{"text": {"concept": "native.Text", "content": {"text": "hello"}}}'
-my-method --inputs data.json
+my_method --inputs '{"text": {"concept": "native.Text", "content": {"text": "hello"}}}'
+my_method --inputs data.json
 ```
 
 When `--inputs` is provided, stdin is ignored entirely. This allows overriding piped data for debugging.
@@ -115,7 +115,7 @@ When `--inputs` is provided, stdin is ignored entirely. This allows overriding p
 When `--inputs` is not provided and stdin is not a TTY (i.e., data is being piped), JSON is read from stdin:
 
 ```bash
-echo '{"text": {"concept": "native.Text", "content": {"text": "hello"}}}' | mthds-agent pipelex run method my-method
+echo '{"text": {"concept": "native.Text", "content": {"text": "hello"}}}' | mthds-agent pipelex run method my_method
 ```
 
 When stdin is a TTY (interactive terminal), no stdin reading occurs and the method runs without inputs.
@@ -206,7 +206,7 @@ extract-terms --inputs data.json \
 
 ```bash
 # The --inputs flag overrides whatever comes from stdin
-echo '{"old": "data"}' | mthds-agent pipelex run method my-method --inputs '{"new": "data"}'
+echo '{"old": "data"}' | mthds-agent pipelex run method my_method --inputs '{"new": "data"}'
 ```
 
 The `--inputs` flag always wins — the stdin data is ignored.

--- a/docs/spec/manifest-format.md
+++ b/docs/spec/manifest-format.md
@@ -24,7 +24,7 @@ A `METHODS.toml` file contains up to three top-level sections:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | The name of the method. MUST be `kebab-case` (matching `[a-z][a-z0-9]*(-[a-z0-9]+)*`), max 25 characters. See [Name](#name). |
+| `name` | string | Yes | The name of the method. MUST be `snake_case` (matching `[a-z][a-z0-9_]*`), 2-25 characters. See [Name](#name). |
 | `address` | string | Yes | Globally unique package identifier. MUST follow the hostname/path pattern. |
 | `display_name` | string | No | Human-friendly display label. When provided, MUST NOT be empty or whitespace-only, MUST NOT exceed 128 characters, and MUST NOT contain Unicode control characters (category Cc). Leading and trailing whitespace is stripped. |
 | `version` | string | Yes | Package version. MUST be valid [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`, with optional pre-release and build metadata). |
@@ -63,15 +63,18 @@ The `name` field is the name of the method. It is the primary identifier for the
 
 **Constraints:**
 
-- MUST be `kebab-case`, matching the pattern `[a-z][a-z0-9]*(-[a-z0-9]+)*`.
-- MUST NOT exceed 25 characters.
+- MUST be `snake_case`, matching the pattern `[a-z][a-z0-9_]*`.
+- MUST be between 2 and 25 characters.
 - MUST NOT be empty.
+
+The package directory name MUST match the `name` field exactly. A compliant tool MUST reject a package whose directory name does not match its manifest name.
 
 **Example:**
 
 ```toml
+# Inside nda_analyzer/METHODS.toml
 [package]
-name    = "nda-analyzer"
+name    = "nda_analyzer"
 address = "github.com/acme/legal-tools"
 ```
 
@@ -91,7 +94,7 @@ The optional `display_name` field provides a human-friendly label for the packag
 
 ```toml
 [package]
-name         = "nda-analyzer"
+name         = "nda_analyzer"
 address      = "github.com/acme/legal-tools"
 display_name = "Nda Analyzer"
 ```
@@ -117,7 +120,7 @@ The current MTHDS standard version is `1.0.0`.
 The optional `main_pipe` field designates the package's primary entry point — the pipe that runs when a user invokes the package by slug or address:
 
 ```bash
-mthds run method nda-analyzer
+mthds run method nda_analyzer
 mthds run method github.com/acme/legal-tools
 ```
 
@@ -131,7 +134,7 @@ mthds run method github.com/acme/legal-tools
 
 ```toml
 [package]
-name      = "nda-analyzer"
+name      = "nda_analyzer"
 address   = "github.com/acme/legal-tools"
 version   = "0.3.0"
 main_pipe = "analyze_nda"
@@ -252,7 +255,7 @@ A package is a directory containing a `METHODS.toml` manifest and one or more `.
 **Minimal package:**
 
 ```
-my-tool/
+my_tool/
 ├── METHODS.toml
 └── main.mthds
 ```
@@ -260,7 +263,7 @@ my-tool/
 **Full package:**
 
 ```
-legal-tools/
+legal_tools/
 ├── METHODS.toml
 ├── methods.lock
 ├── general_legal.mthds
@@ -291,7 +294,7 @@ When loading a `.mthds` bundle, a compliant implementation SHOULD discover the m
 
 ```toml
 [package]
-name          = "nda-analyzer"
+name          = "nda_analyzer"
 address       = "github.com/acme/legal-tools"
 display_name  = "Legal Tools"
 version       = "0.3.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized method names to strict snake_case across the manifest and CLI docs. The spec now requires the package directory to exactly match the manifest name.

- **Migration**
  - Set `[package].name` to snake_case (pattern `[a-z][a-z0-9_]*`, 2–25 chars).
  - Rename the package directory to match the `name` exactly (no conversion).
  - Update CLI/shim usage from kebab-case to snake_case (e.g., my-method → my_method).
  - Republish packages that previously used kebab-case under the new name.

<sup>Written for commit 02dbf713bae3e6ab93d32df6661f38bfcf5a6f9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

