### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.3.0] - 2026-03-04
+
+- Add OpenGraph and Twitter Card meta tags to mike redirect template for social link previews
+- Add mike plugin configuration with custom redirect template
+
 ## [v0.2.1] - 2026-03-03
 
 - Add PipeSearch operator to JSON Schema

--- a/docs/overrides/redirect.html
+++ b/docs/overrides/redirect.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>MTHDS — The Open Standard for AI Methods</title>
-  <meta name="description" content="Official documentation for the MTHDS open standard.">
+  <meta name="description"
+    content="Official documentation for the MTHDS open standard: to give AI methods to AI agents.">
   <!-- OpenGraph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="MTHDS — The Open Standard for AI Methods">
-  <meta property="og:description" content="Official documentation for the MTHDS open standard.">
+  <meta property="og:description"
+    content="Official documentation for the MTHDS open standard: to give AI methods to AI agents.">
   <meta property="og:image" content="https://mthds.ai/latest/images/og-banner.jpeg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -16,7 +19,8 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MTHDS — The Open Standard for AI Methods">
-  <meta name="twitter:description" content="Official documentation for the MTHDS open standard.">
+  <meta name="twitter:description"
+    content="Official documentation for the MTHDS open standard: to give AI methods to AI agents.">
   <meta name="twitter:image" content="https://mthds.ai/latest/images/og-banner.jpeg">
   <!-- Redirect -->
   <noscript>
@@ -28,7 +32,9 @@
     );
   </script>
 </head>
+
 <body>
   Redirecting to <a href="{{href}}">{{href}}</a>...
 </body>
+
 </html>

--- a/docs/overrides/redirect.html
+++ b/docs/overrides/redirect.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MTHDS — The Open Standard for AI Methods</title>
+  <meta name="description" content="Official documentation for the MTHDS open standard.">
+  <!-- OpenGraph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="MTHDS — The Open Standard for AI Methods">
+  <meta property="og:description" content="Official documentation for the MTHDS open standard.">
+  <meta property="og:image" content="https://mthds.ai/latest/images/og-banner.jpeg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://mthds.ai/">
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="MTHDS — The Open Standard for AI Methods">
+  <meta name="twitter:description" content="Official documentation for the MTHDS open standard.">
+  <meta name="twitter:image" content="https://mthds.ai/latest/images/og-banner.jpeg">
+  <!-- Redirect -->
+  <noscript>
+    <meta http-equiv="refresh" content="1; url={{href}}" />
+  </noscript>
+  <script>
+    window.location.replace(
+      "{{href}}" + window.location.search + window.location.hash
+    );
+  </script>
+</head>
+<body>
+  Redirecting to <a href="{{href}}">{{href}}</a>...
+</body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: MTHDS
 site_url: https://mthds.ai/
-site_description: "Official documentation for the MTHDS open standard;to give AI methods to AI agents."
+site_description: "Official documentation for the MTHDS open standard: to give AI methods to AI agents."
 docs_dir: docs
 repo_url: "https://github.com/mthds-ai/mthds"
 repo_name: "MTHDS on GitHub"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: MTHDS
 site_url: https://mthds.ai/
-site_description: "Official documentation for the MTHDS open standard."
+site_description: "Official documentation for the MTHDS open standard;to give AI methods to AI agents."
 docs_dir: docs
 repo_url: "https://github.com/mthds-ai/mthds"
 repo_name: "MTHDS on GitHub"
@@ -43,6 +43,8 @@ extra:
     provider: mike
 
 plugins:
+  - mike:
+      redirect_template: docs/overrides/redirect.html
   - search
   - privacy:
       links_attr_map:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.2.1"
+version = "0.3.0"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

- Add OpenGraph and Twitter Card meta tags to mike's redirect template so social link previews work on `mthds.ai`
- Add mike plugin configuration with custom redirect template
- Update site description

## Test plan

- [ ] Merge and deploy with `mike deploy 0.3.0 latest --update-aliases --push`
- [ ] Run `mike set-default latest --push` to regenerate root redirect with OG tags
- [ ] Test `https://mthds.ai/` on an OpenGraph validator (e.g. opengraph.xyz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to MkDocs/mike documentation configuration and a new static redirect template; impact is mainly on site redirects and social preview metadata.
> 
> **Overview**
> Adds a custom `mike` `redirect_template` (`docs/overrides/redirect.html`) that injects OpenGraph and Twitter Card meta tags into the version redirect page while preserving the existing redirect behavior.
> 
> Updates `mkdocs.yml` to enable/configure the `mike` plugin to use this template and refreshes `site_description`; bumps the project version to `0.3.0` and records the release in `CHANGELOG.md` (with corresponding `uv.lock` version update).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46dc628d00935bb521de158892943aeb5b315244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a custom mike redirect template with OpenGraph and Twitter Card tags so links to mthds.ai render rich previews. Configures mike to use it, updates the site description, bumps to v0.3.0, and fixes a minor typo.

- **Migration**
  - Deploy and update aliases: mike deploy 0.3.0 latest --update-aliases --push
  - Regenerate the default redirect: mike set-default latest --push
  - Validate OG tags for https://mthds.ai/ using an OpenGraph checker (e.g., opengraph.xyz)

<sup>Written for commit 46dc628d00935bb521de158892943aeb5b315244. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

