### PR TITLE
Fix OG tags on /latest/ by switching mike alias_type to copy

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ extra:
 
 plugins:
   - mike:
+      alias_type: copy
       redirect_template: docs/overrides/redirect.html
   - search
   - privacy:


### PR DESCRIPTION
## Summary
- Switches mike `alias_type` from `redirect` (default) to `copy` in `mkdocs.yml`
- With `copy`, the `/latest/` directory becomes a full duplicate of the versioned build, so all assets (images, CSS, JS) are served directly instead of returning 404
- Fixes `/latest/images/og-banner.jpeg` returning 404, which broke OpenGraph previews on `/latest/` URLs

## Test plan
- [ ] After merge, redeploy with `mike deploy <version> latest --update-aliases --push` and `mike set-default latest --push`
- [ ] Verify `curl -sI https://mthds.ai/latest/images/og-banner.jpeg` returns 200
- [ ] Verify `curl -s https://mthds.ai/latest/ | grep 'og:'` shows OG tags
- [ ] Test on https://opengraph.xyz for `/`, `/latest/`, and `/0.3.0/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change limited to the MkDocs `mike` versioning plugin; main risk is altered `/latest/` publishing behavior or increased build output size.
> 
> **Overview**
> Updates `mkdocs.yml` to set the MkDocs `mike` plugin `alias_type` to `copy` (instead of the default redirect behavior).
> 
> This makes the `/latest/` alias publish a full copy of the selected version so assets under `/latest/` resolve correctly (e.g., OG images/resources), rather than relying on redirects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d81a27b49aec21ef339b80734e40d637515f89c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched mike alias_type to copy so /latest/ is a full copy of the current version and serves all assets directly. Fixes 404s for /latest/images/og-banner.jpeg and restores OpenGraph previews on /latest URLs.

- **Migration**
  - Redeploy: mike deploy <version> latest --update-aliases --push; mike set-default latest --push
  - Verify: curl -sI https://mthds.ai/latest/images/og-banner.jpeg returns 200 and OG tags render (e.g., via opengraph.xyz)

<sup>Written for commit 2d81a27b49aec21ef339b80734e40d637515f89c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

