### PR TITLE
Fix docs quality issues: nb_output example, cross-refs, concept heade…

### DIFF
--- a/docs/language/bundles.md
+++ b/docs/language/bundles.md
@@ -52,7 +52,7 @@ Header fields appear at the top of the file, before any `[concept]` or `[pipe]` 
 |-------|----------|-------------|
 | `domain` | Yes | The domain this bundle belongs to. Determines the namespace for all concepts and pipes defined in this file. |
 | `description` | No | A human-readable description of what this bundle provides. |
-| `system_prompt` | No | A default system prompt applied to all `PipeLLM` pipes in this bundle that do not define their own. |
+| `system_prompt` | No | A default system prompt applied to all `PipeLLM` pipes in this bundle that do not define their own. When a PipeLLM pipe omits its own `system_prompt`, it inherits the bundle-level value. A pipe that defines its own `system_prompt` overrides the bundle default. |
 | `main_pipe` | No | The pipe code of the bundle's primary entry point. Auto-exported when the bundle is part of a package. |
 
 The `domain` field is the only required header. It assigns a namespace to everything in the file — more on this in [Domains](domains.md).

--- a/docs/language/concepts.md
+++ b/docs/language/concepts.md
@@ -20,6 +20,49 @@ These concepts exist as named types. They have no internal structure — they ar
 
 **Naming rule:** Concept codes must be `PascalCase`, matching the pattern `[A-Z][a-zA-Z0-9]*`. Examples: `ContractClause`, `UserProfile`, `CVAnalysis`.
 
+### Naming Guidelines
+
+Beyond the PascalCase rule, follow these principles for clear, reusable concept names:
+
+**1. Define what it is, not what it's for.**
+
+```toml
+[concept]
+# Avoid — includes usage context
+TextToSummarize = "Text that needs to be summarized"
+
+# Prefer — defines the essence
+Article = "A written composition on a specific topic"
+```
+
+A concept should describe the nature of the data, not the role it plays in a particular pipe.
+
+**2. Use singular forms.**
+
+```toml
+[concept]
+# Avoid — plural form
+Invoices = "Commercial documents from sellers"
+
+# Prefer — singular form
+Invoice = "A commercial document issued by a seller to a buyer"
+```
+
+Concepts are always singular. Use [multiplicity](multiplicity.md) to express quantity.
+
+**3. Avoid unnecessary adjectives.**
+
+```toml
+[concept]
+# Avoid — includes subjective qualifier
+LongArticle = "A lengthy written composition"
+
+# Prefer — neutral description
+Article = "A written composition on a specific topic"
+```
+
+Keep concept names factual and neutral. Qualitative distinctions belong in the pipe logic, not in the concept name.
+
 ## Structured Concepts
 
 When a concept needs internal structure — specific fields with types — use a `[concept.<ConceptCode>]` sub-table:
@@ -160,6 +203,26 @@ MTHDS provides a set of built-in concepts that are always available in every bun
 Native concepts can be referenced by bare code (`Text`, `Image`) or by qualified reference (`native.Text`, `native.Image`). Bare native codes always take priority during name resolution.
 
 A bundle cannot declare a concept with the same code as a native concept. For example, defining `[concept] Text = "My custom text"` is an error.
+
+### Native Concept Fields
+
+The most commonly used native concepts have the following fields. These are the fields you can reference in prompts via dot notation (e.g., `$page_content.page_view`).
+
+**Text** — a single `text` field containing the string value.
+
+**Image** — `url` (location of the image), `source_prompt` (the prompt used to generate it, if applicable), `caption` (descriptive text), `base_64` (base64-encoded image data, alternative to URL).
+
+**Document** — `url` (location of the document file), `mime_type` (e.g., `"application/pdf"`).
+
+**Number** — a single `number` field (integer or floating-point).
+
+**TextAndImages** — `text` (the text content), `images` (a list of images associated with the text).
+
+**Page** — `text_and_images` (the extracted text and embedded images from the page), `page_view` (a screenshot or rendering of the entire page as an image).
+
+**SearchResult** — `answer` (the synthesized answer text), `sources` (a list of source citations, each with `name`, `url`, and `snippet`).
+
+**JSON** — a single `json_obj` field containing the JSON object.
 
 ## See Also
 

--- a/docs/language/multiplicity.md
+++ b/docs/language/multiplicity.md
@@ -1,0 +1,248 @@
+---
+description: "Learn how multiplicity controls whether pipes accept and produce single items or lists — and why concepts stay singular."
+---
+
+# Multiplicity
+
+Multiplicity defines how many items a pipe accepts as input or produces as output. It is expressed with bracket notation on concept references and is fundamental to building methods that handle both single items and collections.
+
+## Philosophy: Concepts Are Always Singular
+
+Concepts are always defined in the singular form. Define `Keyword`, not `Keywords`. Define `Invoice`, not `Invoices`.
+
+This is not just a naming convention — it is a design principle. A concept describes a semantic entity: what something *is*. The number of items is a circumstantial detail of the method, not part of the concept's identity:
+
+- A pipe that extracts keywords might find 3 or 30 — each is still a `Keyword`.
+- A pipe that generates product ideas might produce 5 or 10 — each remains a `ProductIdea`.
+
+By keeping concepts singular and expressing quantity through multiplicity, MTHDS maintains a clean separation between semantics (what) and cardinality (how many).
+
+## Output Multiplicity
+
+Output multiplicity controls how many items a pipe produces. It is specified using bracket notation in the `output` field.
+
+### Single Output (default)
+
+When no brackets are used, the pipe produces exactly one item:
+
+```toml
+[pipe.summarize]
+type        = "PipeLLM"
+description = "Create a summary of the document"
+inputs      = { document = "Text" }
+output      = "Summary"
+prompt      = "Summarize this document concisely: @document"
+```
+
+### Variable Output (`[]`)
+
+Empty brackets let the model decide how many items to produce:
+
+```toml
+[pipe.extract_line_items]
+type        = "PipeLLM"
+description = "Extract all line items from an invoice"
+inputs      = { invoice_text = "Text" }
+output      = "LineItem[]"
+prompt      = """
+Extract all line items from this invoice:
+
+@invoice_text
+
+For each line item, extract the description, quantity, unit price, and total amount.
+"""
+```
+
+The pipe extracts however many line items appear in the invoice — 2 for a simple receipt, 50 for a detailed purchase order.
+
+**Common use cases:**
+
+- Extract entities from text (unknown count in advance)
+- List all items that match criteria
+- Identify all occurrences of a pattern
+
+### Fixed Output (`[N]`)
+
+A number in brackets produces an exact count:
+
+```toml
+[pipe.generate_headline_options]
+type        = "PipeLLM"
+description = "Generate headline alternatives"
+inputs      = { article_text = "Text" }
+output      = "Headline[5]"
+prompt      = """
+Read this article:
+
+@article_text
+
+Generate 5 different headline options for this article. Make each one unique and compelling.
+"""
+```
+
+**Common use cases:**
+
+- Generate N alternatives for A/B testing
+- Create a fixed set of options for user selection
+- Produce a specific number of variations for comparison
+
+### The `nb_output` Field
+
+In a `PipeSequence` step, the `nb_output` field provides an alternative to bracket notation. It overrides the output multiplicity declared on the called pipe for that particular step invocation:
+
+```toml
+[pipe.generate_email_variants]
+type        = "PipeSequence"
+description = "Generate subject lines for an email"
+inputs      = { email_body = "EmailContent" }
+output      = "SubjectLine[]"
+steps = [
+    { pipe = "generate_subject_lines", nb_output = 3, result = "subject_lines" },
+]
+```
+
+Here, `generate_subject_lines` may declare `output = "SubjectLine"` (singular), but `nb_output = 3` on the step tells the runtime to produce 3 items for this invocation. The `$_nb_output` variable is automatically available in the called pipe's prompt and reflects this value.
+
+## Input Multiplicity
+
+Input multiplicity specifies whether a pipe expects a single item or a list. It uses the same bracket notation, applied to concept references in the `inputs` field.
+
+### Single Input (default)
+
+No brackets — the pipe expects exactly one item:
+
+```toml
+inputs = { report = "Report" }
+```
+
+### Variable Input (`[]`)
+
+Empty brackets — the pipe expects a list of indeterminate length:
+
+```toml
+[pipe.summarize_all_documents]
+type        = "PipeLLM"
+description = "Create a unified summary of multiple documents"
+inputs      = { documents = "Document[]" }
+output      = "Summary"
+prompt      = """
+Analyze all of these documents:
+
+@documents
+
+Create a single unified summary that captures the key points across all documents.
+"""
+```
+
+### Fixed Input (`[N]`)
+
+A number in brackets — the pipe expects exactly that many items:
+
+```toml
+[pipe.compare_two_images]
+type        = "PipeLLM"
+description = "Compare exactly two images side by side"
+inputs      = { images = "Image[2]" }
+output      = "Comparison"
+prompt      = """
+Compare these two images in detail:
+
+@images
+
+Describe their similarities, differences, and relative strengths.
+"""
+```
+
+## Practical Use Cases
+
+### Batch Processing with Variable Input
+
+Process an unknown number of invoices, extracting structured data from each:
+
+```toml
+[pipe.extract_single_invoice]
+type        = "PipeLLM"
+description = "Extract data from one invoice"
+inputs      = { invoice_image = "InvoiceImage" }
+output      = "InvoiceData"
+prompt      = "Extract all fields from this invoice: @invoice_image"
+
+[pipe.process_invoice_batch]
+type        = "PipeSequence"
+description = "Process multiple invoices"
+inputs      = { invoice_images = "InvoiceImage[]" }
+output      = "InvoiceData"
+steps = [
+    { pipe = "extract_single_invoice", batch_over = "invoice_images", batch_as = "invoice_image", result = "all_invoice_data" }
+]
+```
+
+### Fixed Alternatives for Comparison
+
+Generate exactly 3 subject line variations for A/B testing:
+
+```toml
+[pipe.generate_subject_lines]
+type        = "PipeLLM"
+description = "Generate 3 subject line options"
+inputs      = { email_body = "EmailContent" }
+output      = "SubjectLine[3]"
+prompt      = """
+Email content:
+@email_body
+
+Generate 3 compelling subject lines for this email.
+Each should use a different persuasion technique.
+"""
+```
+
+### Entity Extraction with Unknown Count
+
+Extract all company names mentioned in a document:
+
+```toml
+[pipe.extract_companies]
+type        = "PipeLLM"
+description = "Extract all company names from an article"
+inputs      = { article = "Article" }
+output      = "CompanyName[]"
+prompt      = """
+Read this article:
+
+@article
+
+Extract all company and organization names mentioned in the article.
+Only include entities that are explicitly named.
+"""
+```
+
+## Best Practices
+
+**When to use variable output (`[]`):**
+
+- The number of outputs depends on the content being analyzed
+- You are extracting or identifying items (entities, keywords, issues)
+- The count is not known until after processing
+
+**When to use fixed output (`[N]`):**
+
+- You need a specific number for downstream processes
+- You are generating alternatives for comparison or selection
+- External requirements dictate a fixed count
+
+**When to use variable input (`[]`):**
+
+- The pipe should handle batches of unknown size
+- You are aggregating or summarizing multiple items
+- You want maximum flexibility in how the pipe is called
+
+**When to use fixed input (`[N]`):**
+
+- The operation inherently requires a specific count (e.g., comparison of 2 items)
+- The prompt logic depends on an exact number of inputs
+
+## See Also
+
+- [Pipes — Operators](pipes-operators.md) — multiplicity syntax in the Common Fields table.
+- [Pipes — Controllers](pipes-controllers.md) — how `PipeBatch` and inline batching interact with list inputs.
+- [Specification: Pipe Definitions](../spec/mthds-format.md#pipe-definitions) — normative reference for multiplicity syntax.

--- a/docs/language/pipes-controllers.md
+++ b/docs/language/pipes-controllers.md
@@ -8,7 +8,7 @@ Controllers are pipes that orchestrate other pipes. They do not perform transfor
 
 ## PipeSequence
 
-Executes a series of pipes in order. Each step's output is added to working memory, where subsequent steps can consume it.
+Executes a series of pipes in order. Each step's output is added to [working memory](working-memory.md), where subsequent steps can consume it.
 
 ```toml
 [pipe.process_document]

--- a/docs/language/pipes-operators.md
+++ b/docs/language/pipes-operators.md
@@ -32,6 +32,8 @@ All pipe types share these base fields:
 | `ConceptName[]` | A variable-length list. |
 | `ConceptName[N]` | A fixed-length list of exactly N items (N ≥ 1). |
 
+See [Multiplicity](multiplicity.md) for a detailed guide on when and how to use each form.
+
 ## PipeLLM
 
 Generates output by invoking a large language model with a prompt.
@@ -69,12 +71,145 @@ cv_pages = "Page"
 
 **Prompt template syntax:**
 
+All three syntaxes below compile to the same Jinja2 template under the hood. The shorthands exist to improve readability:
+
 - `{{ variable_name }}` — standard Jinja2 variable substitution.
-- `@variable_name` — shorthand, preprocessed to Jinja2 syntax.
-- `$variable_name` — shorthand, preprocessed to Jinja2 syntax.
-- Dotted paths are supported: `{{ doc_request.document_type }}`, `@doc_request.priority`.
+- `@variable_name` — shorthand designed for **block-level insertion** of an input's full content. Use `@` when the variable stands on its own line or represents a large block of text.
+- `$variable_name` — shorthand designed for **inline substitution** within a sentence. Use `$` when the variable is embedded in surrounding text.
+
+For example:
+
+```toml
+prompt = """
+Summarize the following article about $topic:
+
+@article_text
+
+Keep the summary under 3 sentences.
+"""
+```
+
+Here, `$topic` is inline (part of the sentence), while `@article_text` is block-level (inserted as a standalone block). Both conventions aid readability — they are not enforced by the runtime.
+
+Dotted paths are supported: `{{ doc_request.document_type }}`, `@doc_request.priority`.
 
 Every variable referenced in the prompt must correspond to a declared input, and every declared input must be referenced in the prompt or system prompt. Unused inputs are rejected.
+
+### Image Inputs
+
+PipeLLM supports vision language models that process both text and images. Declare image inputs in the `inputs` field — they are passed to the model alongside the text prompt.
+
+```toml
+[pipe.describe_image]
+type        = "PipeLLM"
+description = "Describe an image"
+inputs      = { image = "Image" }
+output      = "VisualDescription"
+prompt      = "Describe the provided image in great detail: $image"
+```
+
+Image variables must be tagged with `@` or `$` in the prompt, just like text variables.
+
+**Sub-attribute access with dot notation:** When an input is a structured concept that contains an image field, use dotted paths to reach the image:
+
+```toml
+[pipe.analyze_page_view]
+type        = "PipeLLM"
+description = "Analyze the visual layout of a page"
+inputs      = { "page_content.page_view" = "Image" }
+output      = "LayoutAnalysis"
+prompt      = """
+Analyze the visual layout and design elements of this page: $page_content.page_view
+Focus on typography, spacing, and overall composition.
+"""
+```
+
+**Multiple images:** List each image as a separate input:
+
+```toml
+[pipe.compare_images]
+type        = "PipeLLM"
+description = "Compare two images"
+inputs      = { first_image = "Image", second_image = "Image" }
+output      = "ImageComparison"
+prompt      = "Compare these two images and describe their similarities and differences: $first_image and $second_image"
+```
+
+### Document Inputs
+
+PipeLLM supports documents (PDFs, etc.) as inputs. Documents are passed to the model alongside the text prompt.
+
+```toml
+[pipe.summarize_document]
+type        = "PipeLLM"
+description = "Summarize a document"
+inputs      = { document = "Document" }
+output      = "DocumentSummary"
+prompt      = "Summarize the key points from this document: @document"
+```
+
+Document variables must be tagged with `@` or `$`, just like text and image variables.
+
+**Multiple documents:**
+
+```toml
+[pipe.compare_documents]
+type        = "PipeLLM"
+description = "Compare two documents"
+inputs      = { first_doc = "Document", second_doc = "Document" }
+output      = "DocumentComparison"
+prompt      = "Compare these two documents and describe their similarities and differences: $first_doc and $second_doc"
+```
+
+Text, image, and document inputs can be freely combined in the same pipe.
+
+### Structuring Method
+
+The `structuring_method` field controls how PipeLLM produces structured output (when the output concept has a `structure` table):
+
+- `"direct"` — the model generates JSON conforming to the output schema in a single call. Fast, but depends on the model's ability to produce well-formed JSON.
+- `"preliminary_text"` — a two-step process: the model first generates free-form text, then a second call extracts and structures the information into the target schema. More robust for complex structures.
+
+**More PipeLLM examples:**
+
+Image input with structured output:
+
+```toml
+[concept.TableRow]
+description = "A single row of data from a table"
+
+[concept.TableRow.structure]
+cells = { type = "list", item_type = "text", description = "Cell values in order" }
+
+[concept.TableData]
+description = "Structured data extracted from a table image"
+
+[concept.TableData.structure]
+headers = { type = "list", item_type = "text", description = "Column headers" }
+rows    = { type = "list", item_type = "concept", item_concept_ref = "TableRow", description = "Table rows" }
+
+[pipe.extract_table_from_image]
+type        = "PipeLLM"
+description = "Extract table data from an image"
+inputs      = { image = "Image" }
+output      = "TableData"
+prompt      = "Extract the table data from this image and return the headers and rows: $image"
+```
+
+Combining text and document inputs:
+
+```toml
+[pipe.analyze_with_context]
+type        = "PipeLLM"
+description = "Analyze a document with additional context"
+inputs      = { context = "Text", reference_doc = "Document" }
+output      = "ContextualAnalysis"
+prompt      = """
+Given this context: $context
+
+Analyze the document and explain how it relates to the context: $reference_doc
+"""
+```
 
 ## PipeFunc
 

--- a/docs/language/putting-it-all-together.md
+++ b/docs/language/putting-it-all-together.md
@@ -4,7 +4,7 @@ description: "A complete MTHDS bundle walkthrough showing how concepts, operator
 
 # Putting It All Together
 
-Before moving on to domains and namespace resolution, here is a complete bundle that uses both operators and controllers. It shows how concepts, pipes, and working memory flow together.
+Before moving on to domains and namespace resolution, here is a complete bundle that uses both operators and controllers. It shows how concepts, pipes, and [working memory](working-memory.md) flow together.
 
 ```toml
 domain      = "joke_generation"

--- a/docs/language/working-memory.md
+++ b/docs/language/working-memory.md
@@ -1,0 +1,51 @@
+---
+description: "Understand working memory — the data-flow mechanism that connects pipes in a pipeline run."
+---
+
+# Working Memory
+
+Working memory is the mechanism that enables data flow between pipes. It acts as a temporary store that exists for the duration of a single pipeline run.
+
+## How Data Flows Between Pipes
+
+When pipes are composed inside a controller (such as `PipeSequence`), the output of each pipe needs to reach subsequent pipes. Working memory handles this.
+
+```toml
+[pipe.description_to_tagline]
+type = "PipeSequence"
+description = "From product description to tagline and keywords"
+inputs = { description = "ProductDescription" }
+output = "Keyword[]"
+steps = [
+    { pipe = "generate_tagline", result = "tagline" },
+    { pipe = "extract_keywords", result = "keywords" },
+]
+```
+
+How does `extract_keywords` access the output of `generate_tagline`? Through working memory:
+
+1. When `generate_tagline` completes, its output is stored in working memory under the name specified by `result` — here, `"tagline"`.
+2. `extract_keywords` declares `tagline` in its `inputs`. The runtime matches the input name to the working memory entry and passes the data in.
+
+This name-matching mechanism chains pipes together into a flow of typed data.
+
+## Lifecycle
+
+Working memory follows a simple lifecycle within a pipeline run:
+
+1. **Creation** — Working memory is initialized when the pipeline run starts.
+2. **Population** — The caller's inputs are placed into working memory before the first pipe executes.
+3. **Updates** — After each pipe completes, its output is stored under the name given by the `result` field.
+4. **Access** — Any subsequent pipe can consume data from working memory by declaring a matching name in its `inputs`.
+5. **Disposal** — Working memory is cleared when the pipeline run completes.
+
+## Best Practices
+
+- **Use meaningful names.** Choose descriptive `result` values so the pipeline reads like a narrative: `result = "candidate_skills"` is clearer than `result = "data"`.
+- **Declare clear contracts.** Each pipe's `inputs` field explicitly states what it needs from working memory. This makes dependencies visible at a glance.
+- **Fail fast.** If a required input is missing from working memory, a compliant runtime rejects the run before the pipe executes, producing a clear error rather than a silent failure.
+
+## See Also
+
+- [Pipes — Controllers](pipes-controllers.md) — how PipeSequence, PipeParallel, and PipeBatch use working memory.
+- [Putting It All Together](putting-it-all-together.md) — a complete bundle walkthrough showing working memory in action.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,8 @@ plugins:
         - language/concepts.md: "Concepts"
         - language/pipes-operators.md: "Pipes — Operators"
         - language/pipes-controllers.md: "Pipes — Controllers"
+        - language/working-memory.md: "Working Memory"
+        - language/multiplicity.md: "Multiplicity"
         - language/model-references.md: "Model References"
         - language/putting-it-all-together.md: "Putting It All Together"
         - language/domains.md: "Domains"
@@ -160,6 +162,8 @@ nav:
     - Concepts: language/concepts.md
     - Pipes — Operators: language/pipes-operators.md
     - Pipes — Controllers: language/pipes-controllers.md
+    - Working Memory: language/working-memory.md
+    - Multiplicity: language/multiplicity.md
     - Model References: language/model-references.md
     - Putting It All Together: language/putting-it-all-together.md
     - Domains: language/domains.md


### PR DESCRIPTION
…rs, and item_type

- Rewrite nb_output section in multiplicity.md to correctly show it as a PipeSequence step field instead of a PipeLLM field (was factually wrong)
- Add working-memory.md cross-reference links in pipes-controllers.md and putting-it-all-together.md on first mention of "working memory"
- Add [concept] table headers to naming guideline code blocks in concepts.md so snippets are valid standalone TOML
- Replace invalid item_type = "list" with a proper TableRow concept using item_type = "concept" in pipes-operators.md TableData example
- Add new multiplicity.md and working-memory.md pages with nav and llmstxt
- Expand system_prompt field description in bundles.md
- Expand PipeLLM docs with image/document inputs, structuring method, and prompt template syntax details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and MkDocs navigation updates only, with no changes to runtime behavior or APIs.
> 
> **Overview**
> **Documentation improvements for core language concepts.** Adds new `Multiplicity` and `Working Memory` pages, links to them from the first mentions in controller/walkthrough docs, and includes both pages in `mkdocs.yml` nav/LLMsTxt sections.
> 
> **Clarifies and corrects existing language docs.** Expands bundle-level `system_prompt` inheritance/override behavior, adds concept naming guidelines (with standalone-valid TOML snippets) plus native concept field references, and significantly expands `PipeLLM` docs (prompt shorthand guidance, image/document inputs, and `structuring_method` with updated structured-output examples).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f244ec4df430779e6c1118843965acc561b2284d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves docs accuracy and clarity across the language section. Adds new guides for multiplicity and working memory, and expands `PipeLLM` with prompt syntax, multimodal inputs, and structuring options.

- **New Features**
  - Added new pages: Multiplicity and Working Memory (with nav updates).
  - Expanded `PipeLLM` docs: prompt template syntax (`@`, `$`, dotted paths), image/document inputs, and `structuring_method` modes with examples.
  - Added Naming Guidelines and Native Concept Fields to Concepts.
  - Clarified bundle-level `system_prompt` inheritance and overrides.
  - Linked Operators docs to the new Multiplicity guide.

- **Bug Fixes**
  - Corrected `nb_output` to be a `PipeSequence` step field and provided a proper example.
  - Fixed table extraction example: replaced invalid `item_type = "list"` with a `TableRow` concept using `item_type = "concept"`.
  - Made TOML snippets valid by adding `[concept]` headers in naming examples.
  - Added working memory cross-references in Controllers and the end-to-end bundle walkthrough.

<sup>Written for commit f244ec4df430779e6c1118843965acc561b2284d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

