### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.3.2] - 2026-03-13
+
+- Document PipeCompose template mode: shorthand syntax (`$`, `@`, `@?`), template categories, available filters, and template context
+- Add `@?` conditional insertion pattern to PipeLLM prompt syntax reference
+- Add normative shorthand expansion rules to the specification
+- Add preprocessor guidance and filter-per-category table to implementers runtime docs
+
 ## [v0.3.1] - 2026-03-09
 
 - Expand language docs: file naming conventions, bundle-level system prompt, refinement vs. new concept guidance, and structuring_method details

--- a/Makefile
+++ b/Makefile
@@ -204,13 +204,13 @@ docs-deploy: env
 
 docs-deploy-stable: env
 	$(call PRINT_TITLE,"Deploying stable documentation $(DOCS_VERSION) with latest alias")
-	$(VENV_MIKE) deploy --push --update-aliases --alias-type redirect $(DOCS_VERSION) latest
+	$(VENV_MIKE) deploy --push --update-aliases --alias-type copy $(DOCS_VERSION) latest
 	$(VENV_MIKE) set-default --push latest
 	$(MAKE) docs-deploy-root
 
 docs-deploy-specific-version: env
 	$(call PRINT_TITLE,"Deploying documentation $(DOCS_VERSION) with pre-release alias")
-	$(VENV_MIKE) deploy --push --update-aliases --alias-type redirect $(DOCS_VERSION) pre-release
+	$(VENV_MIKE) deploy --push --update-aliases --alias-type copy $(DOCS_VERSION) pre-release
 	$(MAKE) docs-deploy-root
 
 docs-deploy-root:

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,6 +1,7 @@
 ---
 template: main.html
 title: Page not found
+robots: noindex, nofollow
 ---
 
 # Page not found

--- a/docs/implementers/runtime.md
+++ b/docs/implementers/runtime.md
@@ -149,4 +149,20 @@ When the `template` field of a `PipeCompose` pipe is a table (rather than a plai
 
 The `category` field influences which Jinja2 filters are available. For example, `html` templates get HTML-specific filters, while `llm_prompt` templates get prompt-specific filters. The reference implementation registers different filter sets per category.
 
+**Shorthand preprocessor:** A compliant runtime SHOULD expand the `$`, `@`, and `@?` shorthand patterns into their Jinja2 equivalents before template rendering. See the [specification](../spec/mthds-format.md#template-mode) for the normative expansion rules. The preprocessor runs on the `template` field of PipeCompose as well as the `prompt` and `system_prompt` fields of PipeLLM, PipeImgGen, and PipeSearch.
+
+**Filter registration per category:** The reference implementation registers the following Jinja2 filters based on the template category:
+
+| Category | Registered Filters |
+|----------|-------------------|
+| `basic` | `format`, `tag` |
+| `expression` | *(none)* |
+| `html` | `format`, `tag`, `escape_script_tag` |
+| `markdown` | `format`, `tag`, `escape_script_tag` |
+| `mermaid` | *(none)* |
+| `llm_prompt` | `format`, `tag`, `with_images` |
+| `img_gen_prompt` | `format`, `tag`, `with_images` |
+
+See [Pipes — Operators: Template Mode](../language/pipes-operators.md#template-mode) for the user-facing reference on template categories, filters, and shorthand syntax.
+
 A compliant runtime must support the plain string form of `template`. The table form with `category`, `templating_style`, and `extra_context` is an advanced feature that implementations may support progressively.

--- a/docs/implementers/runtime.md
+++ b/docs/implementers/runtime.md
@@ -149,7 +149,7 @@ When the `template` field of a `PipeCompose` pipe is a table (rather than a plai
 
 The `category` field influences which Jinja2 filters are available. For example, `html` templates get HTML-specific filters, while `llm_prompt` templates get prompt-specific filters. The reference implementation registers different filter sets per category.
 
-**Shorthand preprocessor:** A compliant runtime SHOULD expand the `$`, `@`, and `@?` shorthand patterns into their Jinja2 equivalents before template rendering. See the [specification](../spec/mthds-format.md#template-mode) for the normative expansion rules. The preprocessor runs on the `template` field of PipeCompose as well as the `prompt` and `system_prompt` fields of PipeLLM, PipeImgGen, and PipeSearch.
+**Shorthand preprocessor:** A compliant runtime SHOULD expand the `$`, `@`, and `@?` shorthand patterns into their Jinja2 equivalents before template rendering. See the [specification](../spec/mthds-format.md#template-mode) for the normative expansion rules. The preprocessor runs on the `template` field of PipeCompose, the `prompt` and `system_prompt` fields of PipeLLM, and the `prompt` field of PipeImgGen and PipeSearch.
 
 **Filter registration per category:** The reference implementation registers the following Jinja2 filters based on the template category:
 

--- a/docs/language/pipes-operators.md
+++ b/docs/language/pipes-operators.md
@@ -76,6 +76,7 @@ All three syntaxes below compile to the same Jinja2 template under the hood. The
 - `{{ variable_name }}` — standard Jinja2 variable substitution.
 - `@variable_name` — shorthand designed for **block-level insertion** of an input's full content. Use `@` when the variable stands on its own line or represents a large block of text.
 - `$variable_name` — shorthand designed for **inline substitution** within a sentence. Use `$` when the variable is embedded in surrounding text.
+- `@?variable_name` — shorthand for **conditional insertion**. Renders the variable only if it is truthy (non-empty, non-null). Use `@?` for optional inputs that may or may not be provided.
 
 For example:
 
@@ -85,13 +86,17 @@ Summarize the following article about $topic:
 
 @article_text
 
+@?additional_context
+
 Keep the summary under 3 sentences.
 """
 ```
 
-Here, `$topic` is inline (part of the sentence), while `@article_text` is block-level (inserted as a standalone block). Both conventions aid readability — they are not enforced by the runtime.
+Here, `$topic` is inline (part of the sentence), `@article_text` is block-level (inserted as a standalone block), and `@?additional_context` is conditionally inserted — it only appears if the variable has a value. All three conventions aid readability — they are not enforced by the runtime.
 
 Dotted paths are supported: `{{ doc_request.document_type }}`, `@doc_request.priority`.
+
+For the full reference on shorthand syntax, template categories, and available filters, see [PipeCompose — Template Mode](#template-mode) below.
 
 Every variable referenced in the prompt must correspond to a declared input, and every declared input must be referenced in the prompt or system prompt. Unused inputs are rejected.
 
@@ -336,11 +341,11 @@ description = "Format analysis results into a report"
 inputs      = { analysis = "CVAnalysis", candidate_name = "Text" }
 output      = "Text"
 template    = """
-# Report for {{ candidate_name }}
+# Report for $candidate_name
 
-{{ analysis.summary }}
+@analysis.summary
 
-Skills: {{ analysis.skills }}
+Skills: $analysis.skills
 """
 ```
 
@@ -348,13 +353,91 @@ The `template` field can be a plain string (as above) or a table with additional
 
 ```toml
 [pipe.format_report.template]
-template = "# Report for {{ candidate_name }}"
+template = "# Report for $candidate_name"
 category = "markdown"
 
 [pipe.format_report.template.templating_style]
 tag_style   = "xml"
 text_format = "markdown"
 ```
+
+#### Template Shorthand Syntax
+
+MTHDS templates support three shorthand patterns that are preprocessed into Jinja2 before rendering. Raw Jinja2 (`{{ }}`, `{% %}`) is always available alongside the shorthands.
+
+| Shorthand | Jinja2 Expansion | Purpose |
+|-----------|-----------------|---------|
+| `$variable` | `{{ variable|format() }}` | **Inline substitution** — embed a value within a sentence. |
+| `@variable` | `{{ variable|tag("variable") }}` | **Block insertion** — insert content as a standalone, tagged block. |
+| `@?variable` | `{% if variable %}{{ variable|tag("variable") }}{% endif %}` | **Conditional insertion** — render only if the variable is truthy. |
+
+**Notes:**
+
+- **Dotted paths** are supported with all three patterns: `$user.name`, `@doc.summary`, `@?extra.notes`.
+- **Trailing dots** are treated as punctuation, not part of the path: `$amount.` expands to `{{ amount|format() }}.`
+- **Dollar amounts** like `$100` or `$1,000` are **not** matched — the character after `$` must be a letter or underscore.
+- **Raw Jinja2** is always available: `{{ variable_name }}`, `{% for item in items %}`, etc.
+
+**Example combining all three patterns:**
+
+```toml
+[pipe.compose_prompt]
+type        = "PipeCompose"
+description = "Build an LLM prompt from structured inputs"
+inputs      = { topic = "Text", context = "Text", guidelines = "Text" }
+output      = "Text"
+template    = """
+Write an article about $topic.
+
+@context
+
+@?guidelines
+"""
+```
+
+Here, `$topic` is inlined into the sentence, `@context` is inserted as a tagged block, and `@?guidelines` appears only if the variable has a value.
+
+#### Template Categories
+
+The `category` field determines which Jinja2 filters are registered and how the template environment is configured.
+
+| Category | Use When | Autoescape | Trim Blocks | Available Filters |
+|----------|----------|:----------:|:-----------:|-------------------|
+| `basic` | General-purpose text composition | No | No | `format`, `tag` |
+| `expression` | Simple expression evaluation | No | No | *(none)* |
+| `html` | Generating HTML content | Yes | Yes | `format`, `tag`, `escape_script_tag` |
+| `markdown` | Generating Markdown content | No | Yes | `format`, `tag`, `escape_script_tag` |
+| `mermaid` | Generating Mermaid diagrams | No | No | *(none)* |
+| `llm_prompt` | Composing prompts for LLMs | No | No | `format`, `tag`, `with_images` |
+| `img_gen_prompt` | Composing prompts for image generation | No | No | `format`, `tag`, `with_images` |
+
+**Guidance:** Use `basic` for most templates. Use `html` when generating web content (autoescape prevents XSS). Use `llm_prompt` when composing prompts that may include image references.
+
+#### Available Filters
+
+Filters transform variable content during rendering. The `$` and `@` shorthands apply `format()` and `tag()` automatically — you only need to call filters explicitly when using raw Jinja2 syntax.
+
+| Filter | Syntax | Description | Categories |
+|--------|--------|-------------|------------|
+| `format` | `{{ var|format(text_format?) }}` | Formats a value as text. Optional `text_format` parameter: `plain`, `markdown`, `html`, `json`. Uses the context default if omitted. Applied automatically by `$`. | basic, html, markdown, llm_prompt, img_gen_prompt |
+| `tag` | `{{ var|tag(tag_name?) }}` | Wraps content in tags based on the template's `tag_style`. The tag name defaults to the variable name. Applied automatically by `@` and `@?`. | basic, html, markdown, llm_prompt, img_gen_prompt |
+| `escape_script_tag` | `{{ var|escape_script_tag() }}` | Escapes `</script>` tags to prevent injection. | html, markdown |
+| `with_images` | `{{ var|with_images() }}` | Extracts nested images from structured content and returns text with `[Image N]` placeholders. | llm_prompt, img_gen_prompt |
+
+#### Template Context
+
+All declared inputs are available as variables in the template. The optional `extra_context` field (table form only) injects additional static variables:
+
+```toml
+[pipe.format_report.template]
+template = "Version: $version — Report for $candidate_name"
+category = "basic"
+
+[pipe.format_report.template.extra_context]
+version = "2.0"
+```
+
+Every variable referenced in the template must correspond to a declared input or an `extra_context` key.
 
 **`category` values:** `basic`, `expression`, `html`, `markdown`, `mermaid`, `llm_prompt`, `img_gen_prompt`.
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,6 +3,9 @@
 
 {% block extrahead %}
 {{ super() }} {# keep anything Material already outputs #}
+{% if page and page.meta and page.meta.robots %}
+<meta name="robots" content="{{ page.meta.robots }}">
+{% endif %}
 {# Ensure base URL always ends with / (mike strips trailing slash on versioned deploys) #}
 {% set base_url = config.site_url ~ ('' if config.site_url[-1:] == '/' else '/') %}
 {% set og_title = (page.meta.title if page and page.meta and page.meta.title) or (page.title if page and page.title) or config.site_name %}
@@ -37,6 +40,27 @@
   "url": "https://mthds.ai"
 }
 </script>
+{% if page and page.title %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {{ og_title | tojson }},
+  "description": {{ og_desc | tojson }},
+  "url": "{{ page.canonical_url }}",
+  "publisher": {
+    "@type": "Organization",
+    "name": "MTHDS",
+    "url": "https://mthds.ai"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "{{ config.site_name }}",
+    "url": "https://mthds.ai"
+  }
+}
+</script>
+{% endif %}
 <!-- PostHog analytics -->
 <script>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once unregister opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing identify alias people.set people.set_once set_config reset get_distinct_id getFeatureFlag getFeatureFlagPayload isFeatureEnabled onFeatureFlags reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);

--- a/docs/overrides/redirect.html
+++ b/docs/overrides/redirect.html
@@ -7,6 +7,8 @@
   <title>MTHDS — The Open Standard for AI Methods</title>
   <meta name="description"
     content="Official documentation for the MTHDS open standard: to give AI methods to AI agents.">
+  <link rel="canonical" href="{{href}}">
+  <meta name="robots" content="noindex, follow">
   <!-- OpenGraph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="MTHDS — The Open Standard for AI Methods">

--- a/docs/spec/mthds-format.md
+++ b/docs/spec/mthds-format.md
@@ -627,7 +627,7 @@ MTHDS defines three shorthand patterns that a compliant preprocessor MUST expand
 - When a matched name ends with a `.` (dot), the preprocessor MUST strip the trailing dot from the variable name and place it after the expanded expression (treating it as sentence punctuation).
 - Raw Jinja2 syntax (`{{ }}`, `{% %}`) MUST always be accepted alongside the shorthands.
 
-These shorthands apply to the `template` field of PipeCompose and to the `prompt` and `system_prompt` fields of PipeLLM, PipeImgGen, and PipeSearch. See [Pipes — Operators: Template Mode](../language/pipes-operators.md#template-mode) for the full reference on categories and filters.
+These shorthands apply to the `template` field of PipeCompose, the `prompt` and `system_prompt` fields of PipeLLM, and the `prompt` field of PipeImgGen and PipeSearch. See [Pipes — Operators: Template Mode](../language/pipes-operators.md#template-mode) for the full reference on categories and filters.
 
 **Template blueprint fields (table form):**
 

--- a/docs/spec/mthds-format.md
+++ b/docs/spec/mthds-format.md
@@ -610,6 +610,25 @@ Composes output by assembling data from working memory using either a template o
 
 When `template` is a string, it is a Jinja2 template rendered with the input variables. When `template` is a table, it MUST contain a `template` field (string) and a `category` field, and MAY contain `templating_style` and `extra_context`.
 
+**Template shorthand syntax:**
+
+MTHDS defines three shorthand patterns that a compliant preprocessor MUST expand before Jinja2 rendering:
+
+| Pattern | Expansion | Description |
+|---------|-----------|-------------|
+| `$name` | `{{ name|format() }}` | Inline substitution with formatting. |
+| `@name` | `{{ name|tag("name") }}` | Block insertion with tagging. |
+| `@?name` | `{% if name %}{{ name|tag("name") }}{% endif %}` | Conditional block insertion (renders only if truthy). |
+
+**Rules:**
+
+- A shorthand pattern MUST NOT match when the character immediately following `$`, `@`, or `@?` is a digit (`0`–`9`). This prevents dollar amounts (e.g., `$100`) and version-like strings (e.g., `@2.0`) from being treated as variables.
+- Dotted paths are supported: `$user.name`, `@doc.summary`, `@?extra.notes`. Each segment of the dotted path MUST be a valid identifier.
+- When a matched name ends with a `.` (dot), the preprocessor MUST strip the trailing dot from the variable name and place it after the expanded expression (treating it as sentence punctuation).
+- Raw Jinja2 syntax (`{{ }}`, `{% %}`) MUST always be accepted alongside the shorthands.
+
+These shorthands apply to the `template` field of PipeCompose and to the `prompt` and `system_prompt` fields of PipeLLM, PipeImgGen, and PipeSearch. See [Pipes — Operators: Template Mode](../language/pipes-operators.md#template-mode) for the full reference on categories and filters.
+
 **Template blueprint fields (table form):**
 
 | Field | Type | Required | Description |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ plugins:
   - mike:
       alias_type: copy
       redirect_template: docs/overrides/redirect.html
+      canonical_version: latest
   - search
   - privacy:
       links_attr_map:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.3.1"
+version = "0.3.2"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.3.1"
+version = "0.3.2"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2 and update changelog
- Fix SEO: set mike `canonical_version: latest` so sitemap and canonical tags point to `/latest/` paths (allowed by `robots.txt`) instead of version-specific paths that reset on every release
- Align Makefile `--alias-type copy` with `mkdocs.yml` config
- Add `noindex` to redirect template and 404 page
- Add per-page TechArticle JSON-LD structured data

## Test plan
- [x] `make docs-check` passes with `--strict`
- [ ] After deploy: verify `https://mthds.ai/latest/sitemap.xml` has `/latest/` URLs
- [ ] Verify canonical tags on deployed pages point to `/latest/` paths
- [ ] Submit sitemap in Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly documentation/SEO configuration changes, but they affect canonical URLs, robots indexing behavior, and documentation deployment aliasing, which can impact site discoverability if misconfigured.
> 
> **Overview**
> **Releases `v0.3.2`** by bumping the package version/lockfile and updating the changelog.
> 
> **Expands “template mode” documentation and spec**: adds the `@?` conditional shorthand, documents `$`/`@`/`@?` expansion rules normatively in the spec, and adds runtime implementer guidance including per-category filter registration tables.
> 
> **Adjusts docs deploy + SEO behavior**: aligns `mike` deploy aliasing to `copy`, sets `canonical_version: latest`, adds `robots` controls (including `noindex` for redirects/404), emits per-page `robots` meta, adds canonical link to the redirect template, and injects per-page `TechArticle` JSON-LD structured data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0db0d19777498fd506d844c7bbcb1b1ea25c267. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.3.2 improves docs and SEO. Adds a complete template mode reference (with `$`, `@`, `@?`) and fixes canonical URLs to use `/latest/`, with structured data.

- **New Features**
  - Document PipeCompose template mode: shorthand syntax (`$`, `@`, `@?`), categories, filters, and template context.
  - Add normative shorthand expansion rules in the spec, plus implementer guidance with a per‑category filter table.

- **Bug Fixes**
  - Set `mike` `canonical_version: latest` and align Makefile to `--alias-type copy` so sitemaps and canonical tags use `/latest/`.
  - Add `noindex` to redirect template and 404; include canonical link on redirects; emit robots meta from front matter.
  - Add TechArticle JSON‑LD to docs pages.
  - Correct docs: only `PipeLLM` has `system_prompt`; update shorthand preprocessor scope to cover `PipeLLM` `prompt`/`system_prompt` and `PipeImgGen`/`PipeSearch` `prompt` only.

<sup>Written for commit a0db0d19777498fd506d844c7bbcb1b1ea25c267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

