### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.3.3] - 2026-03-13
+
+- Improve root redirect page styling for better appearance during redirect
+- Add runtime requirement note to first-method getting-started guide
+
 ## [v0.3.2] - 2026-03-13
 
 - Document PipeCompose template mode: shorthand syntax (`$`, `@`, `@?`), template categories, available filters, and template context

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,22 @@ define ROOT_INDEX_HTML
 <meta http-equiv="refresh" content="0;url=/latest/">
 <link rel="canonical" href="https://mthds.ai/latest/">
 <title>MTHDS</title>
+<style>
+    body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #1a1a1a;
+        color: #d4d4d4;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    a { color: #e5e5e5; text-decoration: none; }
+</style>
 </head>
 <body>
-<p>Redirecting to <a href="/latest/">MTHDS Documentation</a>...</p>
+<p>Redirecting to <a href="/latest/">MTHDS Documentation</a>&#8230;</p>
 </body>
 </html>
 endef

--- a/docs/getting-started/first-method.md
+++ b/docs/getting-started/first-method.md
@@ -120,6 +120,9 @@ This file works as a standalone bundle — no manifest, no package, no dependenc
 mthds run summarizer.mthds
 ```
 
+!!! note "Runtime required"
+    Execution requires an MTHDS-compatible runtime. The reference runtime is [Pipelex](https://github.com/Pipelex/pipelex).
+
 ## File Naming Conventions
 
 When organizing `.mthds` files in a project:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.3.2"
+version = "0.3.3"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.3.2"
+version = "0.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

- Improve root redirect page styling for better appearance during redirect
- Add runtime requirement note to first-method getting-started guide
- Bump version to 0.3.3 and update changelog

## Test plan

- [ ] Verify docs build passes (`make docs-check`)
- [ ] Review redirect page styling
- [ ] Confirm runtime note renders correctly on first-method page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus a version bump; no runtime logic or data/security-sensitive code is modified.
> 
> **Overview**
> **Releases `v0.3.3`.** Updates `pyproject.toml` and `uv.lock` to `0.3.3`, and adds a new `CHANGELOG.md` entry describing the release.
> 
> **Polishes docs UX.** Enhances the root `index.html` redirect template (generated via `Makefile`) with inline styling and small copy tweaks, and adds a *Runtime required* note to `docs/getting-started/first-method.md` pointing readers to the reference runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d33bedac132daebe33fd5824af20882eae635a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the docs root redirect page for a better appearance during auto-redirect and adds a runtime requirement note to the first-method guide. Bumps `mthds` to v0.3.3 and updates the changelog.

<sup>Written for commit e3d33bedac132daebe33fd5824af20882eae635a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

