### PR TITLE
Add Pipelex reference runtime line to footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.3.6] - 2026-03-17
+
+- Add visible H1 heading and emphasize key terms on index page
+- Add Pipelex reference runtime line to site footer
+
 ## [v0.3.5] - 2026-03-16
 
 - Fix sitemap.xml double-path bug (`/latest/latest/page/`) by setting `site_url` to bare domain

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,17 +2,19 @@
 description: "MTHDS is an open standard for defining, packaging, and sharing AI methods — giving agents the ability to discover and execute structured, composable AI workflows."
 ---
 
+# MTHDS: the language of executable AI methods
+
 **TLDR**
 
-MTHDS is a declarative language for defining AI methods: discrete, reusable units of cognitive work like extraction, analysis, synthesis, generation. It is built on TOML and introduces two primitives: concepts (semantically typed data named after real domain things) and pipes (deterministic orchestration steps with explicit typed inputs and outputs). Pipes can invoke LLMs, VLMs, OCR, and image generation models, with built-in structured generation.
+MTHDS is a declarative language for defining **AI methods**: discrete, reusable units of cognitive work like extraction, analysis, synthesis, generation. It is built on TOML and introduces two primitives: **concepts** (semantically typed data named after real domain things) and **pipes** (deterministic orchestration steps with explicit typed inputs and outputs). Pipes can invoke LLMs, VLMs, OCR, and image generation models, with built-in *structured generation*.
 
-The typing is conceptual: `NonCompeteClause` is a refinement of `ContractClause`, meaning pipes compose wherever types are compatible, without manual glue code, because the types carry business meaning rather than just structure.
+The typing is **conceptual**: `NonCompeteClause` is a refinement of `ContractClause`, meaning pipes compose wherever types are compatible, without manual glue code, because the types carry *business meaning* rather than just structure.
 
-Methods are executable and composable like Unix tools: a method can be saved as a CLI command, combined with others using standard Unix pipes, or invoked directly by Claude Code. Methods can also be published as packages, used as templates to customize, or called as components from other methods. Teams can share some methods openly and keep their secret sauce private.
+Methods are **executable and composable** like Unix tools: a method can be saved as a CLI command, combined with others using standard Unix pipes, or invoked directly by Claude Code. Methods can also be published as packages, used as templates to customize, or called as components from other methods. Teams can share some methods openly and keep their secret sauce private.
 
-The standard ships with a Claude Code plugin that lets Claude write, modify, and compose methods on your behalf. This makes MTHDS agent-first by design: a domain expert who can describe what they need in plain language can have Claude author the method, which then runs consistently, is testable, and lives in version control.
+The standard ships with a **Claude Code plugin** that lets Claude write, modify, and compose methods on your behalf. This makes MTHDS **agent-first by design**: a domain expert who can describe what they need in plain language can have Claude author the method, which then runs consistently, is testable, and lives in version control.
 
-Where agent skills handle open-ended tasks, methods handle the parts that benefit from being explicit, versioned, and validated. And unlike skills, methods are executable outside the scope of an agent entirely.
+Where agent skills handle open-ended tasks, methods handle the parts that benefit from being **explicit, versioned, and validated**. And unlike skills, methods are *executable outside the scope of an agent entirely*.
 
 - Hub: [mthds.sh](https://mthds.sh)
 - Spec: [github.com/mthds-ai/mthds](https://github.com/mthds-ai/mthds)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ theme:
       icon: material/weather-sunny
       name: Switch to light mode
 
-copyright: "© 2025-2026 Evotis S.A.S."
+copyright: "Reference runtime: <a href='https://github.com/Pipelex/pipelex' target='_blank'>Pipelex</a> (MIT)<br>© 2025-2026 Evotis S.A.S."
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.3.5"
+version = "0.3.6"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.3.5"
+version = "0.3.6"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary
- Adds "Reference runtime: Pipelex (MIT)" line to the site footer, directly above the existing copyright line
- "Pipelex" links to https://github.com/Pipelex/pipelex

## Test plan
- [x] `make docs-check` passes (strict build)
- [ ] `make docs` — visually confirm footer shows both lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Reference runtime: Pipelex (MIT)" link (to https://github.com/Pipelex/pipelex) above the footer copyright, adds a visible H1 on the landing page with clearer emphasis of key terms, and bumps `mthds` to v0.3.6 with a changelog entry.

<sup>Written for commit 86c5d777948dac96c541d39c0dce29dfd1adedd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

