### PR TITLE
Release v0.3.8: Agent-friendly root URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.3.8] - 2026-03-19
+
+- Enrich root index.html with real content for AI agents and scrapers (browsers still redirect instantly)
+- Copy llms.txt and llms-full.txt to domain root for AI agent discovery
+- Add llms.txt paths to robots.txt allowlist
+
 ## [v0.3.7] - 2026-03-17
 
 - Refine robots.txt to block specific paths (/0., /pre-release/, /404.html) instead of broad disallow

--- a/Makefile
+++ b/Makefile
@@ -250,8 +250,8 @@ docs-deploy-root:
 	git push origin gh-pages
 
 docs-delete: env
-	@if [ -z "$(VERSION)" ]; then echo "ERROR: VERSION is required. Usage: make docs-delete VERSION=\"x.y.z [x.y.z ...]\""; exit 1; fi
-	$(call PRINT_TITLE,"Deleting documentation version(s): $(VERSION)")
+	@if [ -z "$(VERSION)" ]; then echo "ERROR: VERSION is required. Usage: make docs-delete VERSION='x.y.z x.y.z ...'"; exit 1; fi
+	$(call PRINT_TITLE,"Deleting documentation versions: $(VERSION)")
 	$(VENV_MIKE) delete --push $(VERSION)
 
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ define ROOT_ROBOTS_TXT
 User-agent: *
 Allow: /latest/
 Allow: /sitemap.xml
+Allow: /llms.txt
+Allow: /llms-full.txt
 Disallow: /0.
 Disallow: /pre-release/
 Disallow: /404.html
@@ -52,23 +54,49 @@ define ROOT_INDEX_HTML
 <meta charset="utf-8">
 <meta http-equiv="refresh" content="0;url=/latest/">
 <link rel="canonical" href="https://mthds.ai/latest/">
-<title>MTHDS</title>
+<title>MTHDS — The Language of Executable AI Methods</title>
+<meta name="description" content="MTHDS is an open standard for defining, packaging, and sharing AI methods — giving agents the ability to discover and execute structured, composable AI workflows.">
+<meta property="og:title" content="MTHDS — The Language of Executable AI Methods">
+<meta property="og:description" content="MTHDS is an open standard for defining, packaging, and sharing AI methods — giving agents the ability to discover and execute structured, composable AI workflows.">
+<meta property="og:url" content="https://mthds.ai/latest/">
+<meta property="og:type" content="website">
 <style>
     body {
         margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        padding: 2rem;
         background: #1a1a1a;
         color: #d4d4d4;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        line-height: 1.6;
+        max-width: 720px;
+        margin: 0 auto;
     }
-    a { color: #e5e5e5; text-decoration: none; }
+    a { color: #7cb3f0; }
+    h1 { color: #e5e5e5; }
+    ul { padding-left: 1.2rem; }
+    .redirect-notice { color: #888; font-size: 0.85rem; margin-top: 2rem; }
 </style>
 </head>
 <body>
-<p>Redirecting to <a href="/latest/">MTHDS Documentation</a>&#8230;</p>
+<h1>MTHDS: The Language of Executable AI Methods</h1>
+<p>MTHDS is a declarative language for defining AI methods: discrete, reusable units of cognitive work like extraction, analysis, synthesis, generation. It is built on TOML and introduces two primitives: concepts (semantically typed data named after real domain things) and pipes (deterministic orchestration steps with explicit typed inputs and outputs). Pipes can invoke LLMs, VLMs, OCR, and image generation models, with built-in structured generation.</p>
+<p>Methods are executable and composable like Unix tools: a method can be saved as a CLI command, combined with others using standard Unix pipes, or invoked directly by Claude Code.</p>
+<h2>Links</h2>
+<ul>
+<li><a href="https://mthds.sh">Hub</a> — Discover and share methods</li>
+<li><a href="https://github.com/mthds-ai/mthds">Spec</a> — The MTHDS open standard repository</li>
+<li><a href="https://github.com/Pipelex/pipelex">Reference implementation</a> — Pipelex runtime</li>
+<li><a href="https://github.com/mthds-ai/skills">Agent skills</a> — Claude Code plugin for MTHDS</li>
+<li><a href="https://go.pipelex.com/vscode">VS Code extension</a></li>
+</ul>
+<h2>Get Started</h2>
+<ul>
+<li><a href="/latest/language/bundles/">Learn the Language</a> — Concepts, pipes, domains, and .mthds files</li>
+<li><a href="/latest/spec/mthds-format/">Read the Specification</a> — File formats, validation rules, resolution algorithms</li>
+<li><a href="/latest/getting-started/first-method/">Write Your First Method</a> — Set up your editor and write your first method</li>
+</ul>
+<p>For AI agents: see <a href="/llms.txt">/llms.txt</a> for a machine-readable index of this documentation.</p>
+<p class="redirect-notice">Redirecting to <a href="/latest/">MTHDS Documentation</a>&#8230;</p>
 </body>
 </html>
 endef
@@ -230,7 +258,7 @@ docs-deploy-specific-version: env
 	$(MAKE) docs-deploy-root
 
 docs-deploy-root:
-	$(call PRINT_TITLE,"Deploying root assets to gh-pages: 404 + robots.txt + index redirect + JSON Schema")
+	$(call PRINT_TITLE,"Deploying root assets to gh-pages: 404 + robots.txt + index + JSON Schema + llms.txt")
 	@git fetch origin gh-pages:gh-pages 2>/dev/null || true; \
 	TMPDIR=$$(mktemp -d); \
 	trap "cd '$(CURDIR)'; git worktree remove '$$TMPDIR' 2>/dev/null || true; rm -rf '$$TMPDIR'" EXIT; \
@@ -243,10 +271,14 @@ docs-deploy-root:
 		sed 's|<loc>https://mthds.ai/[^/]*/|<loc>https://mthds.ai/latest/|g' \
 			"$$TMPDIR/latest/sitemap.xml" > "$$TMPDIR/sitemap.xml"; \
 	fi && \
+	if [ -f "$$TMPDIR/latest/llms.txt" ]; then cp "$$TMPDIR/latest/llms.txt" "$$TMPDIR/llms.txt"; fi && \
+	if [ -f "$$TMPDIR/latest/llms-full.txt" ]; then cp "$$TMPDIR/latest/llms-full.txt" "$$TMPDIR/llms-full.txt"; fi && \
 	cd "$$TMPDIR" && \
 	git add 404.html robots.txt index.html mthds_schema.json && \
 	if [ -f sitemap.xml ]; then git add sitemap.xml; fi && \
-	(git diff --cached --quiet || git commit -m "Update root assets (404.html, robots.txt, index.html, sitemap.xml, mthds_schema.json)") && \
+	if [ -f llms.txt ]; then git add llms.txt; fi && \
+	if [ -f llms-full.txt ]; then git add llms-full.txt; fi && \
+	(git diff --cached --quiet || git commit -m "Update root assets (404.html, robots.txt, index.html, sitemap.xml, mthds_schema.json, llms.txt)") && \
 	git push origin gh-pages
 
 docs-delete: env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.3.7"
+version = "0.3.8"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.3.7"
+version = "0.3.8"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

- Enrich root `index.html` with real content (meta tags, TLDR, key links, entry points) so AI agents and scrapers get meaningful information instead of a bare meta-refresh redirect — browsers still redirect instantly
- Copy `llms.txt` and `llms-full.txt` from `/latest/` to domain root during deploy, so AI agents can discover them at the conventional `/llms.txt` path
- Add `Allow: /llms.txt` and `Allow: /llms-full.txt` to `robots.txt`
- Bump version to 0.3.8

## Test plan

- [x] `make docs-check` passes (strict MkDocs build)
- [ ] After deploy: `curl -s https://mthds.ai/` returns meaningful HTML with meta tags and content
- [ ] After deploy: `curl -s https://mthds.ai/llms.txt` returns the LLM index
- [ ] Browser: visiting `https://mthds.ai/` still redirects to `/latest/` instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the root URL agent-friendly by adding real content to index.html and exposing llms.txt files at the domain root. Keep the instant browser redirect, update robots.txt, and bump `mthds` to v0.3.8.

- New Features
  - Enrich root index.html with meta tags, TLDR, key links, and entry points; browsers still redirect to /latest/.
  - Copy /latest/llms.txt and llms-full.txt to / during deploy for conventional discovery.
  - Allow /llms.txt and /llms-full.txt in robots.txt.

- Bug Fixes
  - Improve docs-delete Makefile target with clearer usage message and title.

<sup>Written for commit 067880708362028e44dbf3bd13e5c0d5acfd6512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

