### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.4.0] - 2026-03-19
+
+- Expand Document concept and PipeExtract operator to support web page URLs alongside file paths
+- Add PipeExtract web page extraction example
+- Define SearchResult sources: a list of source citations, each a Document with `title`, `url`, and `snippet`
+
 ## [v0.3.8] - 2026-03-19
 
 - Enrich root index.html with real content for AI agents and scrapers (browsers still redirect instantly)

--- a/docs/language/concepts.md
+++ b/docs/language/concepts.md
@@ -248,7 +248,7 @@ The most commonly used native concepts have the following fields. These are the 
 
 **Image** — `url` (location of the image), `source_prompt` (the prompt used to generate it, if applicable), `caption` (descriptive text), `base_64` (base64-encoded image data, alternative to URL).
 
-**Document** — `url` (location of the document file or web page), `mime_type` (e.g., `"application/pdf"`).
+**Document** — `url` (location of the document file or web page), `mime_type` (e.g., `"application/pdf"`), `title` (optional display name), `snippet` (optional text excerpt).
 
 **Number** — a single `number` field (integer or floating-point).
 

--- a/docs/language/concepts.md
+++ b/docs/language/concepts.md
@@ -226,7 +226,7 @@ MTHDS provides a set of built-in concepts that are always available in every bun
 | `Dynamic` | A dynamically-typed value. |
 | `Text` | A text string. |
 | `Image` | An image (binary). |
-| `Document` | A document (e.g., PDF). |
+| `Document` | A document (e.g., PDF, web page). |
 | `Html` | HTML content. |
 | `TextAndImages` | Combined text and image content. |
 | `Number` | A numeric value. |
@@ -248,7 +248,7 @@ The most commonly used native concepts have the following fields. These are the 
 
 **Image** — `url` (location of the image), `source_prompt` (the prompt used to generate it, if applicable), `caption` (descriptive text), `base_64` (base64-encoded image data, alternative to URL).
 
-**Document** — `url` (location of the document file), `mime_type` (e.g., `"application/pdf"`).
+**Document** — `url` (location of the document file or web page), `mime_type` (e.g., `"application/pdf"`).
 
 **Number** — a single `number` field (integer or floating-point).
 
@@ -256,7 +256,7 @@ The most commonly used native concepts have the following fields. These are the 
 
 **Page** — `text_and_images` (the extracted text and embedded images from the page), `page_view` (a screenshot or rendering of the entire page as an image).
 
-**SearchResult** — `answer` (the synthesized answer text), `sources` (a list of source citations, each with `name`, `url`, and `snippet`).
+**SearchResult** — `answer` (the synthesized answer text), `sources` (a list of source citations, each a Document with `title`, `url`, and `snippet`).
 
 **JSON** — a single `json_obj` field containing the JSON object.
 

--- a/docs/language/pipes-operators.md
+++ b/docs/language/pipes-operators.md
@@ -272,7 +272,7 @@ model       = "$gen-image-testing"
 
 ## PipeExtract
 
-Extracts structured content from documents (e.g., PDF pages).
+Extracts structured content from documents (e.g., PDF, web pages).
 
 ```toml
 [pipe.extract_cv]
@@ -283,7 +283,18 @@ output      = "Page[]"
 model       = "@default-text-from-pdf"
 ```
 
-**What this does:** Takes a `Document` input and extracts its content as a variable-length list of `Page` objects.
+**Web page extraction:**
+
+```toml
+[pipe.extract_web_article]
+type        = "PipeExtract"
+description = "Extract content from a web page"
+inputs      = { article_url = "Document" }
+output      = "Page[]"
+model       = "@default-extract-web-page"
+```
+
+**What this does:** Takes a `Document` input (a file path, storage URL, or web page URL) and extracts its content as a variable-length list of `Page` objects.
 
 **Key fields:**
 
@@ -295,7 +306,7 @@ model       = "@default-text-from-pdf"
 | `page_views` | No | Whether to generate page views. |
 | `page_views_dpi` | No | DPI for page view rendering. |
 
-**Constraints:** PipeExtract requires exactly one input (typically `Document` or a concept refining it) and the output must be `"Page[]"`.
+**Constraints:** PipeExtract requires exactly one input (typically `Document` or a concept refining it) and the output must be `"Page[]"`. The input document URL can be a web page URL for web content extraction.
 
 ## PipeSearch
 

--- a/docs/spec/mthds-format.md
+++ b/docs/spec/mthds-format.md
@@ -210,7 +210,7 @@ Native concepts are built-in types that are always available in every bundle wit
 | `Dynamic` | `native.Dynamic` | A dynamically-typed value. |
 | `Text` | `native.Text` | A text string. |
 | `Image` | `native.Image` | An image (binary). |
-| `Document` | `native.Document` | A document (e.g., PDF). |
+| `Document` | `native.Document` | A document (e.g., PDF, web page). |
 | `Html` | `native.Html` | HTML content. |
 | `TextAndImages` | `native.TextAndImages` | Combined text and image content. |
 | `Number` | `native.Number` | A numeric value. |
@@ -470,7 +470,7 @@ model        = { model = "flux-pro", quality = "high" }
 
 ## Operator: PipeExtract
 
-Extracts structured content from documents (e.g., PDF pages).
+Extracts structured content from documents (e.g., PDF, web pages).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -488,6 +488,7 @@ Extracts structured content from documents (e.g., PDF pages).
 
 - `inputs` MUST contain exactly one entry. The input concept SHOULD be `Document` or a concept that refines `Document` or `Image`.
 - `output` MUST be `"Page[]"` (a variable-length list of `Page`).
+- When the document URL is a web page, PipeExtract fetches and extracts the page content.
 
 **Example:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.3.8"
+version = "0.4.0"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.3.8"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

- Expand Document concept and PipeExtract operator to support web page URLs alongside file paths
- Add PipeExtract web page extraction example
- Define SearchResult sources: a list of source citations, each a Document with `title`, `url`, and `snippet`
- Bump version to 0.4.0

## Test plan

- [ ] Verify docs build passes (`make docs-check`)
- [ ] Review changelog entry format
- [ ] Confirm version bump in `pyproject.toml` and `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add web page extraction and extend `Document` with optional `title` and `snippet` in v0.4.0. `Document` and `PipeExtract` now support web page URLs, and `SearchResult.sources` returns `Document` citations.

- **New Features**
  - Added optional `title` and `snippet` to `Document`.
  - Added a web article extraction example for `PipeExtract`.

- **Migration**
  - Update `SearchResult.sources` to a list of `Document` items with `title`, `url`, and `snippet` (replaces `name`).

<sup>Written for commit 0371ebbaa7abd1d02c1bbd9589a0d7fd86eccd5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

