### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.4.1] - 2026-03-30
+
+- Fix README links to point to versioned `/latest/` docs URLs
+- Update agent skills reference to agent plugins with correct repo URL
+- Change `plxt` install instruction from `pip` to `uv tool install`
+
 ## [v0.4.0] - 2026-03-29
 
 - Expand Document concept and PipeExtract operator to support web page URLs alongside file paths

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MTHDS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-mthds.ai-blue)](https://mthds.ai/)
+[![Docs](https://img.shields.io/badge/docs-mthds.ai-blue)](https://mthds.ai/latest/)
 
 An open standard for defining, packaging, and distributing AI methods — typed descriptions of what an AI should do, with what inputs, and what outputs it produces.
 
@@ -40,10 +40,10 @@ MTHDS has two pillars:
 
 ## Getting Started
 
-- [Write Your First Method](https://mthds.ai/getting-started/first-method/) — Create a working bundle from scratch
-- [Learn the Language](https://mthds.ai/language/bundles/) — Concepts, pipes, domains, and namespace resolution
-- [Editor Support](https://mthds.ai/tooling/editor-support/) — VS Code / Cursor extension for syntax highlighting, validation, and autocomplete
-- [Full Documentation](https://mthds.ai/)
+- [Write Your First Method](https://mthds.ai/latest/getting-started/first-method/) — Create a working bundle from scratch
+- [Learn the Language](https://mthds.ai/latest/language/bundles/) — Concepts, pipes, domains, and namespace resolution
+- [Editor Support](https://mthds.ai/latest/tooling/editor-support/) — VS Code / Cursor extension for syntax highlighting, validation, and autocomplete
+- [Full Documentation](https://mthds.ai/latest/)
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Where agent skills handle open-ended tasks, methods handle the parts that benefi
 - Hub: [mthds.sh](https://mthds.sh)
 - Spec: [github.com/mthds-ai/mthds](https://github.com/mthds-ai/mthds)
 - Reference implementation: [github.com/Pipelex/pipelex](https://github.com/Pipelex/pipelex)
-- Agent skills: [github.com/mthds-ai/skills](https://github.com/mthds-ai/skills)
+- Agent plugins: [github.com/mthds-ai/mthds-plugins](https://github.com/mthds-ai/mthds-plugins)
 - VS Code extension: [go.pipelex.com/vscode](https://go.pipelex.com/vscode)
 
 <div class="grid cards" markdown>

--- a/docs/tooling/formatting-linting.md
+++ b/docs/tooling/formatting-linting.md
@@ -8,7 +8,7 @@ description: "Use plxt to format and lint .mthds and TOML files — ensure consi
 
 ## Installation
 
-`plxt` is distributed as a standalone binary. Install it from the [`pipelex-tools` PyPI package](https://pypi.org/project/pipelex-tools/) (`pip install pipelex-tools`), or use the bundled version included with the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=pipelex.pipelex).
+`plxt` is distributed as a standalone binary. Install it from the [`pipelex-tools` PyPI package](https://pypi.org/project/pipelex-tools/) (`uv tool install pipelex-tools`), or use the bundled version included with the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=pipelex.pipelex).
 
 ## Formatting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.4.0"
+version = "0.4.1"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://mthds.ai"
+Homepage = "https://mthds.ai/latest/"
 Repository = "https://github.com/mthds-ai/mthds"
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.4.0"
+version = "0.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

- Fix README links to point to versioned `/latest/` docs URLs
- Update agent skills reference to agent plugins with correct repo URL
- Change `plxt` install instruction from `pip` to `uv tool install`
- Bump version to 0.4.1 and update changelog

## Test plan

- [ ] Verify docs build passes (`make docs-check`)
- [ ] Verify README links resolve correctly
- [ ] Verify GitHub release workflow triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.4.1 with versioned docs links, corrected agent plugin repo, and updated `plxt` install to `uv tool install` for clearer setup. Also bumps `mthds` to 0.4.1 and updates the homepage to `/latest/`.

- **Bug Fixes**
  - Fix docs links to `/latest/` and update homepage URL
  - Update agent skills reference to the agent plugins repo
  - Change `plxt` install to `uv tool install pipelex-tools`

<sup>Written for commit 89a563317e074e26215f1bbcfd666283c9fe4851. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

