### PR TITLE
docs: drop native concept ImgGenPrompt from the standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v0.8.0] - 2026-06-22
+
+### Removed
+
+- **Native concept `ImgGenPrompt` (breaking):** Dropped `ImgGenPrompt` from the built-in native concepts. It was structurally identical to `Text` — a built-in concept with no distinct content payload — and `PipeImgGen` never depended on it. **Migration:** replace `ImgGenPrompt` (or `refines = "ImgGenPrompt"`) with `Text` in any `.mthds` bundle.
+
+### Changed
+
+- **PipeImgGen documentation:** Clarified the input model across the language reference and the normative spec. `PipeImgGen` carries a required `prompt` string template (plus an optional `negative_prompt`) and injects its declared `inputs` into that template — `Text` inputs via `$variable`/Jinja2 interpolation, and `Image` inputs (single or list) as reference images rendered to `[Image N]` tokens for image-to-image and editing workflows — rather than consuming a dedicated prompt concept. Added reference-image examples.
+
 ## [v0.7.0] - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Changed
 
-- **PipeImgGen documentation:** Clarified the input model across the language reference and the normative spec. `PipeImgGen` carries a required `prompt` string template (plus an optional `negative_prompt`) and injects its declared `inputs` into that template — `Text` inputs via `$variable`/Jinja2 interpolation, and `Image` inputs (single or list) as reference images rendered to `[Image N]` tokens for image-to-image and editing workflows — rather than consuming a dedicated prompt concept. Added reference-image examples.
+- **PipeImgGen documentation:** Clarified the input model across the language reference and the normative spec. `PipeImgGen` carries a required `prompt` string template (plus an optional `negative_prompt`) and injects its declared `inputs` into that template — `Text` inputs via `$variable`/Jinja2 interpolation, and `Image` inputs (single or list) as reference images rendered to `[Image N]` tokens for image-to-image and editing workflows — rather than consuming a dedicated prompt concept. Added reference-image examples. The `negative_prompt` is a full template like `prompt`: its variables are subject to the same validation (every referenced variable must be a declared input) and the same `$`/`@` shorthand preprocessing.
+
+### Fixed
+
+- **Native-concept lists:** Completed and aligned the inline native-concept lists in the validation rules, namespace resolution, and registry indexing references — they were missing `SearchResult`. All native-concept lists across the docs now share one canonical order (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`).
 
 ## [v0.7.0] - 2026-06-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Pipelex does NOT appear in: the landing page, the Language section, the Package 
 - `MTHDS_STANDARD_VERSION` = `"1.0.0"` (not `"0.2.0"` from the design doc)
 - `RESERVED_DOMAINS` = `{"native", "mthds", "pipelex"}`
 - `NATIVE_PACKAGE_ADDRESS` = `"__native__"`
-- Native concepts: 12 (Dynamic, Text, Image, Document, Html, TextAndImages, Number, ImgGenPrompt, Page, JSON, SearchResult, Anything)
+- Native concepts: the built-in native concepts (Dynamic, Text, Image, Document, Html, TextAndImages, Number, Page, JSON, SearchResult, Anything)
 - Pipe types: 7 operators (PipeLLM, PipeStructure, PipeFunc, PipeImgGen, PipeExtract, PipeSearch, PipeCompose) + 4 controllers (PipeBatch, PipeCondition, PipeParallel, PipeSequence)
 - Concept field types: 8 (text, list, dict, integer, boolean, number, date, concept)
 - Template categories: 7 (basic, expression, html, markdown, mermaid, llm_prompt, img_gen_prompt)

--- a/docs/implementers/validation-rules.md
+++ b/docs/implementers/validation-rules.md
@@ -23,7 +23,7 @@ After parsing TOML into a dictionary, validate the bundle structure:
 2. `domain` MUST be a valid domain code: one or more `snake_case` segments (`[a-z][a-z0-9_]*`) separated by `.`.
 3. `main_pipe`, if present, MUST be `snake_case` and MUST reference a pipe defined in the same bundle.
 4. Concept codes MUST be `PascalCase` (`[A-Z][a-zA-Z0-9]*`).
-5. Concept codes MUST NOT match any native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `Anything`).
+5. Concept codes MUST NOT match any native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`).
 6. Pipe codes MUST be `snake_case` (`[a-z][a-z0-9_]*`).
 7. `refines` and `structure` MUST NOT both be set on the same concept.
 

--- a/docs/implementers/validation-rules.md
+++ b/docs/implementers/validation-rules.md
@@ -23,7 +23,7 @@ After parsing TOML into a dictionary, validate the bundle structure:
 2. `domain` MUST be a valid domain code: one or more `snake_case` segments (`[a-z][a-z0-9_]*`) separated by `.`.
 3. `main_pipe`, if present, MUST be `snake_case` and MUST reference a pipe defined in the same bundle.
 4. Concept codes MUST be `PascalCase` (`[A-Z][a-zA-Z0-9]*`).
-5. Concept codes MUST NOT match any native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `ImgGenPrompt`, `Page`, `JSON`, `Anything`).
+5. Concept codes MUST NOT match any native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `Anything`).
 6. Pipe codes MUST be `snake_case` (`[a-z][a-z0-9_]*`).
 7. `refines` and `structure` MUST NOT both be set on the same concept.
 

--- a/docs/language/concepts.md
+++ b/docs/language/concepts.md
@@ -230,7 +230,6 @@ MTHDS provides a set of built-in concepts that are always available in every bun
 | `Html` | HTML content. |
 | `TextAndImages` | Combined text and image content. |
 | `Number` | A numeric value. |
-| `ImgGenPrompt` | A prompt for image generation. |
 | `Page` | A single page extracted from a document. |
 | `JSON` | A JSON value. |
 | `SearchResult` | A web search result with answer and sources. |

--- a/docs/language/pipes-operators.md
+++ b/docs/language/pipes-operators.md
@@ -355,20 +355,49 @@ prompt      = "A professional portrait: $description"
 model       = "$gen-image-testing"
 ```
 
-**What this does:** Takes a `Text` description, sends it to an image generation model, and produces an `Image` output.
+**What this does:** Renders the `prompt` template — interpolating the `Text` input `description` — sends the result to an image generation model, and produces an `Image` output.
+
+PipeImgGen does not consume a dedicated "prompt" concept. The prompt is a string template declared directly on the pipe, and the pipe's declared `inputs` are injected into that template at runtime:
+
+- **`Text` inputs** are interpolated into the prompt text via `$variable` shorthand or Jinja2.
+- **`Image` inputs** (a single image or a list) are referenced in the prompt and injected as **reference images**: each referenced image is replaced by an `[Image N]` token in the rendered text and passed to the generator alongside it. This is the same vision pattern used for image inputs to `PipeLLM`, and it enables image-to-image, reference-image, and image-editing generation, bounded by the model's image limit.
 
 **Key fields:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `prompt` | Yes | The image generation prompt. Supports Jinja2 and `$variable` shorthand. |
-| `negative_prompt` | No | Concepts to avoid in generation. |
+| `prompt` | Yes | The image generation prompt template. Supports Jinja2 and `$variable` shorthand; declared inputs are injected into it. |
+| `negative_prompt` | No | An optional prompt template describing what to avoid in the generated image. |
 | `model` | No | Model identifier, model reference (see [Model References](model-references.md)), or an inline settings table (see [Inline Settings](model-references.md#inline-settings)). |
 | `aspect_ratio` | No | Desired aspect ratio. Values: `square`, `landscape_4_3`, `landscape_3_2`, `landscape_16_9`, `landscape_21_9`, `portrait_3_4`, `portrait_2_3`, `portrait_9_16`, `portrait_9_21`. |
 | `is_raw` | No | Whether to use raw mode (less post-processing). |
 | `seed` | No | Random seed for reproducibility. Integer value, or `"auto"` to let the model randomize it. |
 | `background` | No | Background setting. Values: `transparent`, `opaque`, `auto`. |
 | `output_format` | No | Image output format. Values: `png`, `jpeg`, `webp`. |
+
+**Reference images (image-to-image):** declare `Image` inputs and reference them in the prompt to condition generation on existing images. A single reference image:
+
+```toml
+[pipe.restyle_photo]
+type        = "PipeImgGen"
+description = "Restyle a photo following a textual instruction"
+inputs      = { source = "Image", instruction = "Text" }
+output      = "Image"
+prompt      = "Restyle this image: $source. $instruction"
+```
+
+A list of reference images, referenced as a group:
+
+```toml
+[pipe.blend_references]
+type        = "PipeImgGen"
+description = "Blend multiple reference images into one composition"
+inputs      = { refs = "Image[]" }
+output      = "Image"
+prompt      = "Combine these references into a single coherent scene: $refs"
+```
+
+Each referenced image becomes an `[Image N]` token in the rendered prompt and is passed to the generator as a reference image, up to the model's image limit.
 
 ## PipeExtract
 

--- a/docs/packages/registry-indexing.md
+++ b/docs/packages/registry-indexing.md
@@ -168,7 +168,7 @@ For every concept in every indexed package, the registry creates a `ConceptNode`
 
 The node key is `{package_address}::{concept_ref}` (e.g., `github.com/acme/legal-tools::legal.contracts.ContractClause`).
 
-The registry MUST also create concept nodes for all native concepts (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `Anything`, `Dynamic`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
+The registry MUST also create concept nodes for all native concepts (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
 
 ### Step 2: Resolve Refinement Targets
 

--- a/docs/packages/registry-indexing.md
+++ b/docs/packages/registry-indexing.md
@@ -168,7 +168,7 @@ For every concept in every indexed package, the registry creates a `ConceptNode`
 
 The node key is `{package_address}::{concept_ref}` (e.g., `github.com/acme/legal-tools::legal.contracts.ContractClause`).
 
-The registry MUST also create concept nodes for all native concepts (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `ImgGenPrompt`, `Page`, `JSON`, `Anything`, `Dynamic`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
+The registry MUST also create concept nodes for all native concepts (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `Anything`, `Dynamic`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
 
 ### Step 2: Resolve Refinement Targets
 

--- a/docs/spec/mthds-format.md
+++ b/docs/spec/mthds-format.md
@@ -214,7 +214,6 @@ Native concepts are built-in types that are always available in every bundle wit
 | `Html` | `native.Html` | HTML content. |
 | `TextAndImages` | `native.TextAndImages` | Combined text and image content. |
 | `Number` | `native.Number` | A numeric value. |
-| `ImgGenPrompt` | `native.ImgGenPrompt` | A prompt for image generation. |
 | `Page` | `native.Page` | A single page extracted from a document. |
 | `JSON` | `native.JSON` | A JSON value. |
 | `SearchResult` | `native.SearchResult` | A web search result with answer and sources. |
@@ -445,7 +444,7 @@ function_name = "my_package.text_utils.capitalize"
 
 ## Operator: PipeImgGen
 
-Generates images using an image generation model.
+Generates images using an image generation model. The pipe carries a required `prompt` string template (and an optional `negative_prompt` template); it does not take a dedicated prompt concept as input. Declared `inputs` are injected into the `prompt` at runtime: `Text` inputs are interpolated into the prompt text, while `Image` inputs (a single image or a list) are referenced in the prompt and injected as reference images — each becomes an `[Image N]` token in the rendered text and is passed to the generator alongside it, enabling image-to-image, reference-image, and image-editing generation.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -453,8 +452,8 @@ Generates images using an image generation model.
 | `description` | string | Yes | — |
 | `inputs` | table | No | — |
 | `output` | string | Yes | — |
-| `prompt` | string | Yes | The image generation prompt. Supports Jinja2 and `$variable` shorthand. |
-| `negative_prompt` | string | No | A negative prompt (concepts to avoid in generation). |
+| `prompt` | string | Yes | The image generation prompt template. Supports Jinja2 and `$variable` shorthand; declared inputs are injected into it. |
+| `negative_prompt` | string | No | An optional prompt template describing what to avoid in the generated image. |
 | `model` | string or table | No | Model identifier, model reference (see [Model References](../language/model-references.md)), or an inline [image generation settings](#inline-image-generation-settings) table. |
 | `aspect_ratio` | string | No | Desired aspect ratio. Values: `square`, `landscape_4_3`, `landscape_3_2`, `landscape_16_9`, `landscape_21_9`, `portrait_3_4`, `portrait_2_3`, `portrait_9_16`, `portrait_9_21`. |
 | `is_raw` | boolean | No | Whether to use raw mode (less post-processing). |
@@ -465,6 +464,8 @@ Generates images using an image generation model.
 **Validation rules:**
 
 - Every variable referenced in `prompt` MUST correspond to a declared input.
+- `output` MUST resolve to an `Image`-compatible concept.
+- Any input referenced as a reference image in the `prompt` MUST resolve to an `Image`-compatible concept (single or list).
 
 **Example:**
 
@@ -476,6 +477,17 @@ inputs      = { description = "Text" }
 output      = "Image"
 prompt      = "A professional portrait: $description"
 model       = "$gen-image-testing"
+```
+
+**Example with a reference image (image-to-image):**
+
+```toml
+[pipe.restyle_photo]
+type        = "PipeImgGen"
+description = "Restyle a source photo following a textual instruction"
+inputs      = { source = "Image", instruction = "Text" }
+output      = "Image"
+prompt      = "Restyle this image: $source. $instruction"
 ```
 
 ### Inline Image Generation Settings

--- a/docs/spec/mthds-format.md
+++ b/docs/spec/mthds-format.md
@@ -463,9 +463,9 @@ Generates images using an image generation model. The pipe carries a required `p
 
 **Validation rules:**
 
-- Every variable referenced in `prompt` MUST correspond to a declared input.
+- Every variable referenced in `prompt` or `negative_prompt` MUST correspond to a declared input.
 - `output` MUST resolve to an `Image`-compatible concept.
-- Any input referenced as a reference image in the `prompt` MUST resolve to an `Image`-compatible concept (single or list).
+- Any input referenced as a reference image in the `prompt` or `negative_prompt` MUST resolve to an `Image`-compatible concept (single or list).
 
 **Example:**
 
@@ -683,7 +683,7 @@ MTHDS defines three shorthand patterns that a compliant preprocessor MUST expand
 - When a matched name ends with a `.` (dot), the preprocessor MUST strip the trailing dot from the variable name and place it after the expanded expression (treating it as sentence punctuation).
 - Raw Jinja2 syntax (`{{ }}`, `{% %}`) MUST always be accepted alongside the shorthands.
 
-These shorthands apply to the `template` field of PipeCompose, the `prompt` and `system_prompt` fields of PipeLLM, and the `prompt` field of PipeImgGen and PipeSearch. See [Pipes — Operators: Template Mode](../language/pipes-operators.md#template-mode) for the full reference on categories and filters.
+These shorthands apply to the `template` field of PipeCompose, the `prompt` and `system_prompt` fields of PipeLLM, the `prompt` and `negative_prompt` fields of PipeImgGen, and the `prompt` field of PipeSearch. See [Pipes — Operators: Template Mode](../language/pipes-operators.md#template-mode) for the full reference on categories and filters.
 
 **Template blueprint fields (table form):**
 

--- a/docs/spec/namespace-resolution.md
+++ b/docs/spec/namespace-resolution.md
@@ -67,7 +67,7 @@ Each segment of a domain path MUST be `snake_case`:
 
 When resolving a bare concept code (no domain qualifier, no package prefix):
 
-1. **Native concepts** — check if the code matches a native concept code (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `ImgGenPrompt`, `Page`, `JSON`, `Dynamic`, `Anything`). Native concepts always take priority.
+1. **Native concepts** — check if the code matches a native concept code (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `Dynamic`, `Anything`). Native concepts always take priority.
 2. **Current bundle** — check concepts declared in the same `.mthds` file.
 3. **Same domain, other bundles** — if the bundle is part of a package, check concepts in other bundles that declare the same domain.
 4. **Error** — if not found in any of the above, the reference is invalid.

--- a/docs/spec/namespace-resolution.md
+++ b/docs/spec/namespace-resolution.md
@@ -67,7 +67,7 @@ Each segment of a domain path MUST be `snake_case`:
 
 When resolving a bare concept code (no domain qualifier, no package prefix):
 
-1. **Native concepts** — check if the code matches a native concept code (`Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `Dynamic`, `Anything`). Native concepts always take priority.
+1. **Native concepts** — check if the code matches a native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`). Native concepts always take priority.
 2. **Current bundle** — check concepts declared in the same `.mthds` file.
 3. **Same domain, other bundles** — if the bundle is part of a package, check concepts in other bundles that declare the same domain.
 4. **Error** — if not found in any of the above, the reference is invalid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mthds"
-version = "0.7.0"
+version = "0.8.0"
 description = "MTHDS is the open standard for creating and sharing executable, composable AI methods."
 authors = [{ name = "Evotis S.A.S.", email = "oss@pipelex.com" }]
 maintainers = [{ name = "Pipelex", email = "oss@pipelex.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -647,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mike" },


### PR DESCRIPTION
## Summary

Drops the native concept `ImgGenPrompt` from the MTHDS standard, following its removal from the Pipelex reference runtime as of pipelex v0.35.1 (breaking, pre-1.0). `native.ImgGenPrompt` was structurally identical to `Text` and carried no semantic payload; migration everywhere is `ImgGenPrompt` → `Text`.

### Removed `ImgGenPrompt` from every native-concept enumeration
- `docs/language/concepts.md`, `docs/spec/mthds-format.md` — native-concept tables
- `docs/spec/namespace-resolution.md`, `docs/implementers/validation-rules.md`, `docs/packages/registry-indexing.md` — inline native-concept lists
- `CLAUDE.md` — removed from the list and de-hardcoded the count (workspace rule: no hardcoded counts)

### Corrected the PipeImgGen input model (language reference + spec)
`PipeImgGen` carries a required `prompt` string template (+ optional `negative_prompt`); declared `inputs` are injected into it — `Text` via `$var`/Jinja interpolation, `Image` (single or list) as reference images rendered to `[Image N]` tokens (the same vision pattern as PipeLLM, enabling image-to-image / editing). There is no dedicated prompt concept. Added reference-image examples and spec validation rules.

### CHANGELOG
Added a `v0.8.0` entry (Removed + Changed).

The `img_gen_prompt` **template category** is unrelated and left untouched.

## Test plan
- [x] \`rg '\bImgGenPrompt\b' docs/ CLAUDE.md\` → zero hits
- [x] \`rg 'img_gen_prompt' docs/\` → template-category references intact
- [x] \`make docs-check\` (\`mkdocs build --strict\` + OpenAPI validation) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wwi2XYnnbDc1y49EvZN5UK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the native concept `ImgGenPrompt` from the MTHDS standard and clarified that `PipeImgGen` uses prompt templates with injected `Text` and reference `Image` inputs. Also normalized native-concept lists to include `SearchResult`, and documented that `negative_prompt` is a full template with the same validation and shorthands. This aligns with Pipelex v0.35.1 and is a breaking change; use `Text` instead of `ImgGenPrompt`.

- **Migration**
  - Replace all `ImgGenPrompt` references (including refines) with `Text` in `.mthds` bundles.
  - On `PipeImgGen`, define `prompt` and `negative_prompt` as templates; interpolate `Text` inputs and inject `Image` inputs as reference images rendered as `[Image N]`; all variables must be declared inputs; `$`/`@` shorthands apply.
  - The `img_gen_prompt` template category is unchanged.

<sup>Written for commit 8df52eb6a02d0c66095253c93f612a9532293cd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mthds-ai/mthds/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

