### PR TITLE
Add YesNo and Date native concept docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Optionality in the language:** Documented first-class `?` / `!` presence markers, recorded absences, liftable pipes, guarded template requirements, and optionality validation diagnostics.
+- **Native concepts `YesNo` and `Date`:** Documented first-class yes/no and date outputs, including their content fields and native concept references.
 
 ### Changed
 
@@ -24,7 +25,7 @@
 
 ### Fixed
 
-- **Native-concept lists:** Completed and aligned the inline native-concept lists in the validation rules, namespace resolution, and registry indexing references — they were missing `SearchResult`. All native-concept lists across the docs now share one canonical order (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`).
+- **Native-concept lists:** Completed and aligned the inline native-concept lists in the validation rules, namespace resolution, and registry indexing references — they were missing `SearchResult`. All native-concept lists across the docs now share one canonical order (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `YesNo`, `Date`, `Page`, `JSON`, `SearchResult`, `Anything`, `Composite`).
 
 ## [v0.7.0] - 2026-06-17
 

--- a/docs/implementers/validation-rules.md
+++ b/docs/implementers/validation-rules.md
@@ -23,7 +23,7 @@ After parsing TOML into a dictionary, validate the bundle structure:
 2. `domain` MUST be a valid domain code: one or more `snake_case` segments (`[a-z][a-z0-9_]*`) separated by `.`.
 3. `main_pipe`, if present, MUST be `snake_case` and MUST reference a pipe defined in the same bundle.
 4. Concept codes MUST be `PascalCase` (`[A-Z][a-zA-Z0-9]*`).
-5. Concept codes MUST NOT match any native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`).
+5. Concept codes MUST NOT match any native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `YesNo`, `Date`, `Page`, `JSON`, `SearchResult`, `Anything`, `Composite`).
 6. Pipe codes MUST be `snake_case` (`[a-z][a-z0-9_]*`).
 7. `refines` and `structure` MUST NOT both be set on the same concept.
 

--- a/docs/language/concepts.md
+++ b/docs/language/concepts.md
@@ -230,10 +230,13 @@ MTHDS provides a set of built-in concepts that are always available in every bun
 | `Html` | HTML content. |
 | `TextAndImages` | Combined text and image content. |
 | `Number` | A numeric value. |
+| `YesNo` | The answer to a yes/no question. |
+| `Date` | A calendar date, optionally with a time of day. |
 | `Page` | A single page extracted from a document. |
 | `JSON` | A JSON value. |
 | `SearchResult` | A web search result with answer and sources. |
 | `Anything` | Accepts any type. |
+| `Composite` | A named composition of contents. |
 
 Native concepts can be referenced by bare code (`Text`, `Image`) or by qualified reference (`native.Text`, `native.Image`). Bare native codes always take priority during name resolution.
 
@@ -251,6 +254,10 @@ The most commonly used native concepts have the following fields. These are the 
 
 **Number** — a single `number` field (integer or floating-point).
 
+**YesNo** — a single `yes_no` field (boolean). Renders as `yes` when true and `no` when false.
+
+**Date** — `date` (ISO 8601 calendar date), `time` (optional ISO 8601 time, with UTC offset when the source states one). A Date never uses numeric epoch input and never invents a midnight time.
+
 **TextAndImages** — `text` (the text content), `images` (a list of images associated with the text).
 
 **Page** — `text_and_images` (the extracted text and embedded images from the page), `page_view` (a screenshot or rendering of the entire page as an image).
@@ -258,6 +265,8 @@ The most commonly used native concepts have the following fields. These are the 
 **SearchResult** — `answer` (the synthesized answer text), `sources` (a list of source citations, each a Document with `title`, `url`, and `snippet`).
 
 **JSON** — a single `json_obj` field containing the JSON object.
+
+**Composite** — dynamically named component fields. PipeParallel uses this when branch results are combined without a bespoke structured output concept.
 
 ## See Also
 

--- a/docs/packages/registry-indexing.md
+++ b/docs/packages/registry-indexing.md
@@ -168,7 +168,7 @@ For every concept in every indexed package, the registry creates a `ConceptNode`
 
 The node key is `{package_address}::{concept_ref}` (e.g., `github.com/acme/legal-tools::legal.contracts.ContractClause`).
 
-The registry MUST also create concept nodes for all native concepts (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
+The registry MUST also create concept nodes for all native concepts (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `YesNo`, `Date`, `Page`, `JSON`, `SearchResult`, `Anything`, `Composite`). Native concepts use the package address `__native__` and concept references prefixed with `native.` (e.g., `native.Text`).
 
 ### Step 2: Resolve Refinement Targets
 

--- a/docs/spec/mthds-format.md
+++ b/docs/spec/mthds-format.md
@@ -214,10 +214,13 @@ Native concepts are built-in types that are always available in every bundle wit
 | `Html` | `native.Html` | HTML content. |
 | `TextAndImages` | `native.TextAndImages` | Combined text and image content. |
 | `Number` | `native.Number` | A numeric value. |
+| `YesNo` | `native.YesNo` | The answer to a yes/no question. |
+| `Date` | `native.Date` | A calendar date, optionally with a time of day. |
 | `Page` | `native.Page` | A single page extracted from a document. |
 | `JSON` | `native.JSON` | A JSON value. |
 | `SearchResult` | `native.SearchResult` | A web search result with answer and sources. |
 | `Anything` | `native.Anything` | Accepts any type. |
+| `Composite` | `native.Composite` | A named composition of contents. |
 
 Native concepts MAY be referenced by bare code (`Text`, `Image`) or by qualified reference (`native.Text`, `native.Image`). Bare native concept codes always take priority during resolution.
 

--- a/docs/spec/namespace-resolution.md
+++ b/docs/spec/namespace-resolution.md
@@ -67,7 +67,7 @@ Each segment of a domain path MUST be `snake_case`:
 
 When resolving a bare concept code (no domain qualifier, no package prefix):
 
-1. **Native concepts** — check if the code matches a native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `Page`, `JSON`, `SearchResult`, `Anything`). Native concepts always take priority.
+1. **Native concepts** — check if the code matches a native concept code (`Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `YesNo`, `Date`, `Page`, `JSON`, `SearchResult`, `Anything`, `Composite`). Native concepts always take priority.
 2. **Current bundle** — check concepts declared in the same `.mthds` file.
 3. **Same domain, other bundles** — if the bundle is part of a package, check concepts in other bundles that declare the same domain.
 4. **Error** — if not found in any of the above, the reference is invalid.


### PR DESCRIPTION
## Summary
- Add YesNo and Date to official native concept tables and field docs.
- Align native collision, namespace resolution, and registry-indexing lists with the current native concept set, including Composite.

## Tests
- make docs-check
- make docs-assemble-site
- make -C pipelex gms
- make -C pipelex cms
- python3 internal-tools/plugins/mthds-schema-sync/scripts/schema_diff.py --reference dev (reports existing v0.38 consumer drift vs hosted v0.27; no local pipelex schema change from this work)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for native concepts `YesNo` and `Date`, and aligns all native-concept lists to a single canonical order (now including `Composite`) across validation, namespace resolution, and registry indexing. This clarifies fields and avoids name-collision and indexing inconsistencies.

- **New Features**
  - Documented `YesNo` (boolean `yes_no`, renders “yes”/“no”) and `Date` (ISO `date`, optional ISO `time` with offset; no epoch, no invented midnight) in concepts and spec.
  - Added `Composite` to the native concept reference with dynamically named component fields.

- **Bug Fixes**
  - Unified native-concept lists and examples across docs with the canonical order: `Dynamic`, `Text`, `Image`, `Document`, `Html`, `TextAndImages`, `Number`, `YesNo`, `Date`, `Page`, `JSON`, `SearchResult`, `Anything`, `Composite`.

<sup>Written for commit 97e928ee7afa4adbcc899b844f9bbb3b2ebdcc2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mthds-ai/mthds/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

