### PR TITLE
ci-cd: run docs-check on dev pull requests, and watch every included file

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,12 +2,18 @@ name: Documentation Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
+      # The repo-root files the docs pages pull in with `--8<--` snippet
+      # includes; a build is strict about their links, so an edit to one of
+      # them can break the site without touching docs/.
+      - "CHANGELOG.md"
+      - "CODE_OF_CONDUCT.md"
       - "CONTRIBUTING.md"
+      - "LICENSE"
       - ".github/workflows/docs-check.yml"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 - **Future Directions** (`packages/future-directions.md`): New page preserving the package ecosystem's ambitions — typed signature search, the Know-How Graph's query surface, Ed25519-signed manifests with a trust store, and registry proxy/mirror chains — explicitly as non-normative directions, each compatible with the registry-off-the-install-path invariant.
 
+### Fixed
+
+- **The documentation build is gated on the pull requests that carry the work.** `docs-check` declared `on: pull_request: branches: [main]`, but by convention every ordinary pull request targets `dev`, so the gate ran only on release pull requests and a broken docs build surfaced at the release rather than at the change that caused it. It now runs on both bases. Its `paths` filter also watched only one of the four repo-root files the docs pull in through `--8<--` snippet includes, so an edit to `CHANGELOG.md`, `CODE_OF_CONDUCT.md` or `LICENSE` could break the strict build without triggering it; all four are watched now.
+
 ### Removed
 
 - **`packages/registry-search.md` and `packages/registry-distribution.md`:** Their honest content (text search, package signals) moved into the registry overview; the speculative content (typed search semantics, graph queries, signed manifests, proxy chains) moved to the Future Directions page.


### PR DESCRIPTION
## What

Two holes in the `docs-check` trigger, both found while landing #60.

**It never ran on the pull requests that carry the work.** `docs-check` declared `on: pull_request: branches: [main]`, but by the workspace convention every ordinary pull request targets `dev`. So the gate fired only on release pull requests, and `gh pr checks` on a `dev` pull request answered `no checks reported` with an empty `statusCheckRollup` — absence that reads exactly like a clean bill of health. A broken documentation build reached `dev` unnoticed and surfaced at the release, blocking the release instead of the change that caused it. It now runs on both bases.

**Its `paths` filter watched one of the four files the docs actually include.** Four repo-root files are pulled into the built site through `--8<--` snippet includes:

| Page | Includes |
|---|---|
| `docs/changelog.md` | `CHANGELOG.md` |
| `docs/contributing.md` | `CONTRIBUTING.md` |
| `docs/CODE_OF_CONDUCT.md` | `CODE_OF_CONDUCT.md` |
| `docs/license.md` | `LICENSE` |

Only `CONTRIBUTING.md` was in the filter. A strict build resolves links inside an included file against the *including page's* directory, so an edit to any of these can break the site without touching `docs/` at all. That is not hypothetical — it is what happened on #60, where a changelog link that was correct on GitHub failed `mkdocs build --strict` once included into `docs/changelog.md`. All four are watched now.

## What is deliberately left alone

`changelog-check` and `version-check` stay on `main` only. Both compare `pyproject.toml` against the changelog heading and the branch name, so they are release-shaped gates with nothing to say about a `dev` pull request. Widening them would fail every ordinary pull request in the repo.

## Verification

`make docs-check` passes locally, and this pull request should be its own proof: it targets `dev` and touches both `.github/workflows/docs-check.yml` and `CHANGELOG.md`, so under the new trigger the job must appear on it — where under the old one no check would have run at all.

Closes L-260902-f53cdc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NbaBhCKt2PTFHKUHsNUiZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs-check workflow so it gates documentation builds on dev pull requests and watches every repo-root file the docs include, closing a gap that let broken docs builds reach dev unnoticed and surface at release.

- The trigger previously ran only on PRs targeting main; it now runs on both main and dev.
- The paths filter previously watched only CONTRIBUTING.md; it now also watches CHANGELOG.md, CODE_OF_CONDUCT.md, and LICENSE.

**Deliberately left alone**
- `changelog-check` and `version-check` stay on main only; both compare against the changelog heading and branch name, so they have nothing to say about a dev pull request.

Closes L-260902-f53cdc.

<sup>Written for commit a6e60910234ee6322979f08d692d405948e49cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mthds-ai/mthds/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

